### PR TITLE
Add provisioning for expected Lambda's CloudWatch Log Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ A3: This probably mean that zip-archive has been deployed, but is currently abse
 | attach\_policy\_statements | Controls whether policy\_statements should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | attach\_tracing\_policy | Controls whether X-Ray tracing policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | build\_in\_docker | Whether to build dependencies in Docker | `bool` | `false` | no |
+| cloudwatch\_logs\_retention | Number of days to retain CloudWatch Logs (also requires `attach_cloudwatch_logs_policy`) | `number` | 0 | no |
 | compatible\_runtimes | A list of Runtimes this layer is compatible with. Up to 5 runtimes can be specified. | `list(string)` | `[]` | no |
 | create | Controls whether resources should be created | `bool` | `true` | no |
 | create\_async\_event\_config | Controls whether async event configuration for Lambda Function/Alias should be created | `bool` | `false` | no |

--- a/logs.tf
+++ b/logs.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_group" "lambda" {
+  count = local.create_role && var.attach_cloudwatch_logs_policy && ! var.lambda_at_edge ? 1 : 0
+  name = "/aws/lambda/${var.function_name}"
+  retention_in_days = var.cloudwatch_logs_retention
+}
+
+resource "aws_cloudwatch_log_group" "lambda-edge" {
+  count = local.create_role && var.attach_cloudwatch_logs_policy && var.lambda_at_edge ? 1 : 0
+  name = "/aws/lambda/us-east-1.${var.function_name}"
+  retention_in_days = var.cloudwatch_logs_retention
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,3 +91,10 @@ output "s3_object" {
   description = "The map with S3 object data of zip archive deployed (if deployment was from S3)"
   value       = map("bucket", local.s3_bucket, "key", local.s3_key, "version_id", local.s3_object_version)
 }
+
+# CloudWatch Log Group
+output "cloudwatch_log_group" {
+  description = "The ARN of the Cloudwatch Log Group"
+  value       = element(concat(local.log_group_arns, [""]), 0)
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -251,6 +251,16 @@ variable "allowed_triggers" {
   default     = {}
 }
 
+#################
+# CloudWatch Logs
+#################
+
+variable "cloudwatch_logs_retention" {
+  description = "Number of days to retain CloudWatch Logs (also requires `attach_cloudwatch_logs_policy`)"
+  type        = number
+  default     = 0
+}
+
 ######
 # IAM
 ######


### PR DESCRIPTION
Closes terraform-aws-modules/terraform-aws-lambda#22

## Description
- Adds ability to set a retention time for the Lambda's CloudWatch Logs.
- Adds the Log Group to the outputs to allow for easy-attach of a
  subscriber.
- Retains the default `Never Expire` (days == 0) behavior and logs are
  not created if `create_role` or `attach_cloudwatch_logs_policy` are false;
  expectation is the CWLogGroup would be handled externally in that case.

## Motivation and Context
Would like to _not_ pay to retain old, crufty CloudWatch Logs
Would also like an easy way to attach a consumer to my Lambda's CWE Log Group.

## Breaking Changes
Not breaking; retains existing, expected behavior.

## How Has This Been Tested?
Used the examples/simple tf in this repo and twiddled some bits around a few times, changing the retention and `false`'ing variables like `attach_cloudwatch_logs_policy`.
