### PR TITLE
Updates archive_prepare to use local.python as the runtime

### DIFF
--- a/package.tf
+++ b/package.tf
@@ -26,7 +26,7 @@ data "external" "archive_prepare" {
     }) : null
 
     artifacts_dir    = var.artifacts_dir
-    runtime          = var.runtime
+    runtime          = local.python
     source_path      = jsonencode(var.source_path)
     hash_extra       = var.hash_extra
     hash_extra_paths = jsonencode(["${path.module}/package.py"])


### PR DESCRIPTION
## Description
Use the system default python runtime when building the lambda archive without docker

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm using `pyenv` to manage python on my machine and without this change the python version must be explicitly set. Not sure if this is just a misconfig on my end but this change seemed simple enough and I don't _think_ it alters core functionality - unless I'm missing something.

## Breaking Changes
None?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running this from Ubuntu 18.04 LTS

relevant `terraform apply` output prior to this change: 

```
module.lambda_function.null_resource.archive[0]: Provisioning with 'local-exec'...
module.lambda_function.null_resource.archive[0] (local-exec): Executing: ["python3" ".terraform/modules/lambda_function/package.py" "build" "--timestamp" "1592508494071385000" "builds/b548a6f33e3794ec3c272a4a41f0d1e164a2d5ea6084aa48d13270fdc24e74df.plan.json"]
module.lambda_function.null_resource.archive[0] (local-exec): zip: creating 'builds/b548a6f33e3794ec3c272a4a41f0d1e164a2d5ea6084aa48d13270fdc24e74df.zip' archive
module.lambda_function.null_resource.archive[0] (local-exec): Installing python requirements: ./lambda/requirements.txt
module.lambda_function.null_resource.archive[0] (local-exec): > mktemp -d terraform-aws-lambda-XXXXXXXX # /tmp/terraform-aws-lambda-5g2w50b2
module.lambda_function.null_resource.archive[0] (local-exec): > cd /tmp/terraform-aws-lambda-5g2w50b2
module.lambda_function.null_resource.archive[0] (local-exec): > python3.7 -m pip install --no-compile --prefix= --target=. --requirement=requirements.txt
```

relevant `terraform apply` output with this change: 

```
module.lambda_function.null_resource.archive[0] (local-exec): Executing: ["python3" ".terraform/modules/lambda_function/package.py" "build" "--timestamp" "1592508766218947800" "builds/57a5116ab18759bf413e7039ea45741e4c9ae15a85311ffaa4e160dc4cf8aa9c.plan.json"]
module.lambda_function.null_resource.archive[0] (local-exec): zip: creating 'builds/57a5116ab18759bf413e7039ea45741e4c9ae15a85311ffaa4e160dc4cf8aa9c.zip' archive
module.lambda_function.null_resource.archive[0] (local-exec): Installing python requirements: ./lambda/requirements.txt
module.lambda_function.null_resource.archive[0] (local-exec): > mktemp -d terraform-aws-lambda-XXXXXXXX # /tmp/terraform-aws-lambda-c8b2g29o
module.lambda_function.null_resource.archive[0] (local-exec): > cd /tmp/terraform-aws-lambda-c8b2g29o
module.lambda_function.null_resource.archive[0] (local-exec): > python3 -m pip install --no-compile --prefix= --target=. --requirement=requirements.txt
```