### PR TITLE
fix: Adds region wildcard to log group arn when lambda@edge

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -14,6 +14,19 @@ resource "random_pet" "this" {
   length = 2
 }
 
+//module "lambda_at_edge" {
+//  source = "../../"
+//
+//  function_name = "${random_pet.this.id}-lambda-edge"
+//  handler       = "index.lambda_handler"
+//  runtime       = "python3.8"
+//  lambda_at_edge = true
+//
+//  attach_cloudwatch_logs_policy = true
+//
+//  source_path = "${path.module}/../fixtures/python3.8-app1/"
+//}
+
 //resource "aws_cloudwatch_log_group" "this" {
 //  name = "/aws/lambda/us-east-1.${random_pet.this.id}-lambda-simple"
 //}

--- a/iam.tf
+++ b/iam.tf
@@ -4,7 +4,7 @@ locals {
   # Lambda@Edge uses the Cloudwatch region closest to the location where the function is executed
   # The region part of the LogGroup ARN is then replaced with a wildcard (*) so Lambda@Edge is able to log in every region
   log_group_arn_regional = element(concat(data.aws_cloudwatch_log_group.lambda.*.arn, aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
-  log_group_arn          = var.lambda_at_edge ? join(":", ["arn", data.aws_arn.log_group_arn.partition, data.aws_arn.log_group_arn.service, "*", data.aws_arn.log_group_arn.account, data.aws_arn.log_group_arn.resource]) : local.log_group_arn_regional
+  log_group_arn          = local.create_role && var.lambda_at_edge ? format("arn:%s:%s:%s:%s:%s", data.aws_arn.log_group_arn[0].partition, data.aws_arn.log_group_arn[0].service, "*", data.aws_arn.log_group_arn[0].account, data.aws_arn.log_group_arn[0].resource) : local.log_group_arn_regional
 }
 
 ###########
@@ -43,6 +43,8 @@ resource "aws_iam_role" "lambda" {
 ##################
 
 data "aws_arn" "log_group_arn" {
+  count = local.create_role && var.lambda_at_edge ? 1 : 0
+
   arn = local.log_group_arn_regional
 }
 


### PR DESCRIPTION
## Description
When Lambda@Edge is used it replaces the region in the resource ARN of the IAM policy with a wildcard (*).
Lambda@Edge is then able to put its logs in every region where it is executed.

Resolves #34.
