### PR TITLE
feat: Add support for EFS File System Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This Terraform module is the part of [serverless.tf framework](https://github.co
 - [x] Lambda@Edge
 - [x] Conditional creation for many types of resources.
 - [x] Control execution of nearly any step in the process - build, package, store package, deploy, update.
-- [x] Control nearly all aspects of Lambda resources (provisioned concurrency, VPC, dead-letter notification, tracing, async events, IAM role, IAM policies, and more).
+- [x] Control nearly all aspects of Lambda resources (provisioned concurrency, VPC, EFS, dead-letter notification, tracing, async events, IAM role, IAM policies, and more).
 - [x] Support integration with other `serverless.tf` modules like [HTTP API Gateway](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2) (see [examples there](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/tree/master/examples/complete-http)).
 
 
@@ -547,6 +547,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 * [Deploy](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/deploy) - Complete end-to-end build/update/deploy process using AWS CodeDeploy.
 * [Async Invocations](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/async) - Create Lambda Function with async event configuration (with SQS and SNS integration).
 * [With VPC](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/with-vpc) - Create Lambda Function with VPC.
+* [With EFS](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/with-efs) - Create Lambda Function with Elastic File System attached (Terraform 0.13+ is recommended).
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -606,6 +606,8 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | docker\_pip\_cache | Whether to mount a shared pip cache folder into docker environment or not | `any` | `null` | no |
 | docker\_with\_ssh\_agent | Whether to pass SSH\_AUTH\_SOCK into docker environment or not | `bool` | `false` | no |
 | environment\_variables | A map that defines environment variables for the Lambda Function. | `map(string)` | `{}` | no |
+| file\_system\_arn | The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system. | `string` | `null` | no |
+| file\_system\_local\_mount\_path | The path where the function can access the file system, starting with /mnt/. | `string` | `null` | no |
 | function\_name | A unique name for your Lambda Function | `string` | `""` | no |
 | handler | Lambda Function entrypoint in your code | `string` | `""` | no |
 | hash\_extra | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -56,14 +56,6 @@ module "lambda_function" {
     }
   }
 
-
-  ######################
-  # Elastic File System
-  ######################
-
-  file_system_arn              = aws_efs_access_point.lambda.arn
-  file_system_local_mount_path = "/mnt/shared-storage/"
-
   ######################
   # Additional policies
   ######################
@@ -240,27 +232,6 @@ module "s3_bucket" {
   bucket        = "${random_pet.this.id}-bucket"
   force_destroy = true
 }
-
-resource "aws_efs_file_system" "shared" {}
-
-resource "aws_efs_access_point" "lambda" {
-  file_system_id = aws_efs_file_system.shared.id
-
-  posix_user {
-    gid = 1000
-    uid = 1000
-  }
-
-  root_directory {
-    path = "/lambda"
-    creation_info {
-      owner_gid   = 1000
-      owner_uid   = 1000
-      permissions = "0777"
-    }
-  }
-}
-
 
 resource "aws_sqs_queue" "dlq" {
   name = random_pet.this.id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -56,6 +56,14 @@ module "lambda_function" {
     }
   }
 
+
+  ######################
+  # Elastic File System
+  ######################
+
+  file_system_arn              = aws_efs_access_point.lambda.arn
+  file_system_local_mount_path = "/mnt/shared-storage/"
+
   ######################
   # Additional policies
   ######################
@@ -232,6 +240,27 @@ module "s3_bucket" {
   bucket        = "${random_pet.this.id}-bucket"
   force_destroy = true
 }
+
+resource "aws_efs_file_system" "shared" {}
+
+resource "aws_efs_access_point" "lambda" {
+  file_system_id = aws_efs_file_system.shared.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/lambda"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "0777"
+    }
+  }
+}
+
 
 resource "aws_sqs_queue" "dlq" {
   name = random_pet.this.id

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -1,0 +1,56 @@
+# AWS Lambda with EFS example
+
+Configuration in this directory creates AWS Lambda Function deployed with Elastic File System (EFS) attached.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| random | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
+| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
+| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
+| local\_filename | The filename of zip archive deployed (if deployment was from local) |
+| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| this\_lambda\_function\_arn | The ARN of the Lambda Function |
+| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
+| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
+| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
+| this\_lambda\_function\_name | The name of the Lambda Function |
+| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
+| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
+| this\_lambda\_function\_version | Latest published version of Lambda Function |
+| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
+| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
+| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
+| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
+| this\_lambda\_layer\_version | The Lambda Layer version |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -23,6 +23,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
+| aws | n/a |
 | random | n/a |
 
 ## Inputs

--- a/examples/with-efs/main.tf
+++ b/examples/with-efs/main.tf
@@ -63,7 +63,7 @@ resource "aws_efs_file_system" "shared" {}
 resource "aws_efs_mount_target" "alpha" {
   file_system_id  = aws_efs_file_system.shared.id
   subnet_id       = module.vpc.intra_subnets[0]
-    security_groups = [module.vpc.default_security_group_id]
+  security_groups = [module.vpc.default_security_group_id]
 }
 
 resource "aws_efs_access_point" "lambda" {

--- a/examples/with-efs/main.tf
+++ b/examples/with-efs/main.tf
@@ -1,0 +1,85 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  # Make it faster by skipping something
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+module "lambda_function_with_efs" {
+  source = "../../"
+
+  function_name = "${random_pet.this.id}-lambda-in-vpc"
+  description   = "My awesome lambda function"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  source_path = "${path.module}/../fixtures/python3.8-app1"
+
+  vpc_subnet_ids         = module.vpc.intra_subnets
+  vpc_security_group_ids = [module.vpc.default_security_group_id]
+  attach_network_policy  = true
+
+  ######################
+  # Elastic File System
+  ######################
+
+  file_system_arn              = aws_efs_access_point.lambda.arn
+  file_system_local_mount_path = "/mnt/shared-storage"
+
+  # Explicitly declare dependency on EFS mount target.
+  # When creating or updating Lambda functions, mount target must be in 'available' lifecycle state.
+  # Note: depends_on on modules became available in Terraform 0.13
+  depends_on = [aws_efs_mount_target.alpha]
+}
+
+######
+# VPC
+######
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = random_pet.this.id
+  cidr = "10.10.0.0/16"
+
+  azs           = ["eu-west-1a"]
+  intra_subnets = ["10.10.101.0/24"]
+}
+
+######
+# EFS
+######
+
+resource "aws_efs_file_system" "shared" {}
+
+resource "aws_efs_mount_target" "alpha" {
+  file_system_id  = aws_efs_file_system.shared.id
+  subnet_id       = module.vpc.intra_subnets[0]
+    security_groups = [module.vpc.default_security_group_id]
+}
+
+resource "aws_efs_access_point" "lambda" {
+  file_system_id = aws_efs_file_system.shared.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/lambda"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "0777"
+    }
+  }
+}

--- a/examples/with-efs/outputs.tf
+++ b/examples/with-efs/outputs.tf
@@ -1,0 +1,99 @@
+# Lambda Function
+output "this_lambda_function_arn" {
+  description = "The ARN of the Lambda Function"
+  value       = module.lambda_function_with_efs.this_lambda_function_arn
+}
+
+output "this_lambda_function_invoke_arn" {
+  description = "The Invoke ARN of the Lambda Function"
+  value       = module.lambda_function_with_efs.this_lambda_function_invoke_arn
+}
+
+output "this_lambda_function_name" {
+  description = "The name of the Lambda Function"
+  value       = module.lambda_function_with_efs.this_lambda_function_name
+}
+
+output "this_lambda_function_qualified_arn" {
+  description = "The ARN identifying your Lambda Function Version"
+  value       = module.lambda_function_with_efs.this_lambda_function_qualified_arn
+}
+
+output "this_lambda_function_version" {
+  description = "Latest published version of Lambda Function"
+  value       = module.lambda_function_with_efs.this_lambda_function_version
+}
+
+output "this_lambda_function_last_modified" {
+  description = "The date Lambda Function resource was last modified"
+  value       = module.lambda_function_with_efs.this_lambda_function_last_modified
+}
+
+output "this_lambda_function_kms_key_arn" {
+  description = "The ARN for the KMS encryption key of Lambda Function"
+  value       = module.lambda_function_with_efs.this_lambda_function_kms_key_arn
+}
+
+output "this_lambda_function_source_code_hash" {
+  description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
+  value       = module.lambda_function_with_efs.this_lambda_function_source_code_hash
+}
+
+output "this_lambda_function_source_code_size" {
+  description = "The size in bytes of the function .zip file"
+  value       = module.lambda_function_with_efs.this_lambda_function_source_code_size
+}
+
+# Lambda Layer
+output "this_lambda_layer_arn" {
+  description = "The ARN of the Lambda Layer with version"
+  value       = module.lambda_function_with_efs.this_lambda_layer_arn
+}
+
+output "this_lambda_layer_layer_arn" {
+  description = "The ARN of the Lambda Layer without version"
+  value       = module.lambda_function_with_efs.this_lambda_layer_layer_arn
+}
+
+output "this_lambda_layer_created_date" {
+  description = "The date Lambda Layer resource was created"
+  value       = module.lambda_function_with_efs.this_lambda_layer_created_date
+}
+
+output "this_lambda_layer_source_code_size" {
+  description = "The size in bytes of the Lambda Layer .zip file"
+  value       = module.lambda_function_with_efs.this_lambda_layer_source_code_size
+}
+
+output "this_lambda_layer_version" {
+  description = "The Lambda Layer version"
+  value       = module.lambda_function_with_efs.this_lambda_layer_version
+}
+
+# IAM Role
+output "lambda_role_arn" {
+  description = "The ARN of the IAM role created for the Lambda Function"
+  value       = module.lambda_function_with_efs.lambda_role_arn
+}
+
+output "lambda_role_name" {
+  description = "The name of the IAM role created for the Lambda Function"
+  value       = module.lambda_function_with_efs.lambda_role_name
+}
+
+# CloudWatch Log Group
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The ARN of the Cloudwatch Log Group"
+  value       = module.lambda_function_with_efs.lambda_cloudwatch_log_group_arn
+}
+
+# Deployment package
+output "local_filename" {
+  description = "The filename of zip archive deployed (if deployment was from local)"
+  value       = module.lambda_function_with_efs.local_filename
+}
+
+output "s3_object" {
+  description = "The map with S3 object data of zip archive deployed (if deployment was from S3)"
+  value       = module.lambda_function_with_efs.s3_object
+}

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,14 @@ resource "aws_lambda_function" "this" {
     }
   }
 
+  dynamic "file_system_config" {
+    for_each = var.file_system_arn != null && var.file_system_local_mount_path != null ? [true] : []
+    content {
+      local_mount_path = var.file_system_local_mount_path
+      arn              = var.file_system_arn
+    }
+  }
+
   tags = var.tags
 
   depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package]

--- a/variables.tf
+++ b/variables.tf
@@ -413,6 +413,18 @@ variable "policy_statements" {
   default     = {}
 }
 
+variable "file_system_arn" {
+  description = "The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system."
+  type        = string
+  default     = null
+}
+
+variable "file_system_local_mount_path" {
+  description = "The path where the function can access the file system, starting with /mnt/."
+  type        = string
+  default     = null
+}
+
 ##########################
 # Build artifact settings
 ##########################

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = ">= 2.46, < 4.0"
+    aws = ">= 2.67, < 4.0"
   }
 }


### PR DESCRIPTION
## Description
Resolves #44

## Motivation and Context
To support the new `file_system_config` which allows Lambdas to have EFS file systems mounted.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- Tested on a project that requires file_system_config. 
- Tested Plan & Apply. Works as expected.
	```
	Terraform v0.12.29
	+ provider.aws v2.70.0
	+ provider.external v1.2.0
	+ provider.local v1.4.0
	+ provider.null v2.1.2
	```

	```
	Terraform v0.13.0
	+ provider registry.terraform.io/hashicorp/aws v2.70.0
	+ provider registry.terraform.io/hashicorp/external v1.2.0
	+ provider registry.terraform.io/hashicorp/local v1.4.0
	+ provider registry.terraform.io/hashicorp/null v2.1.2
	```