### PR TITLE
Update lambda timeout to 15 minutes max

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "this" {
   reserved_concurrent_executions = var.reserved_concurrent_executions
   runtime                        = var.runtime
   layers                         = var.layers
-  timeout                        = var.lambda_at_edge ? min(var.timeout, 5) : var.timeout
+  timeout                        = var.lambda_at_edge ? min(var.timeout, 15) : var.timeout
   publish                        = var.lambda_at_edge ? true : var.publish
   kms_key_arn                    = var.kms_key_arn
 


### PR DESCRIPTION
## Description
Update the lambda maximum timeout to 15 minutes from 5.

## Motivation and Context
This change is inline with the lambda maximum timeout being raised by Amazon from 5 minutes to 15.
https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/#:~:text=You%20can%20now%20configure%20your,Lambda%20function%20was%205%20minutes.

## Breaking Changes
Could raise timeout on deployments were the settings were above 5 minutes.

## How Has This Been Tested?
Tested via deploying sample function. Changes are minimal.
