### PR TITLE
feat: allow aws provider v3 to be used with Terraform 0.12

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.46"
+    aws = ">= 2.46, < 4"
   }
 }


### PR DESCRIPTION
## Disclaimer

It's most likely wrong to target the `master` branch, but I didn't see any Terraform 0.12 specific branches. I'll leave it up to you to re-target this PR :dart: Hence the merge conflict.

## Description

Allows the AWS provider v3 to be used, and generally relaxes the version requirement previously set to `~> 2.46`.

## Motivation and Context

To solve https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/102

## Breaking Changes

None compared to `v1.6.0`.

## How Has This Been Tested?

Ran `terraform init` while referencing this in a dependency tree where `aws 3.1` was successfully used.

Closes terraform-aws-modules/terraform-aws-notify-slack#102.