### PR TITLE
fix: Added support for AWS provider v3 used by notify-slack module with Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,13 +529,13 @@ A3: This probably mean that zip-archive has been deployed, but is currently abse
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.6 |
-| aws | ~> 2.46 |
+| aws | >= 2.46, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.46 |
+| aws | >= 2.46, < 4.0 |
 | external | n/a |
 | local | n/a |
 | null | n/a |

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.46"
+    aws = ">= 2.46, < 4.0"
   }
 }


### PR DESCRIPTION
Closes #48