### PR TITLE
fix: Removed hash_extra_paths to have the same hash for multiple executors

### DIFF
--- a/package.tf
+++ b/package.tf
@@ -29,7 +29,14 @@ data "external" "archive_prepare" {
     runtime          = var.runtime
     source_path      = jsonencode(var.source_path)
     hash_extra       = var.hash_extra
-    hash_extra_paths = jsonencode(["${path.module}/package.py"])
+    hash_extra_paths = jsonencode(
+      [
+        # Temporary fix when building from multiple locations
+        # We should take into account content of package.py when counting hash
+        # Related issue: https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/63
+        # "${path.module}/package.py"
+      ]
+    )
   }
 }
 


### PR DESCRIPTION
Fixes #63