### PR TITLE
feat: Add support for creating lambdas that use Container Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tfstate
 *.tfvars
 *.tfplan
+.terraform.lock.hcl
 
 builds/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This Terraform module is the part of [serverless.tf framework](https://github.co
 
 - [x] Build dependencies for your Lambda Function and Layer.
 - [x] Support builds locally and in Docker (with or without SSH agent support for private builds).
-- [x] Create deployment package or deploy existing (previously built package) from local, from S3, from URL.
+- [x] Create deployment package or deploy existing (previously built package) from local, from S3, from URL, or from AWS ECR repository.
 - [x] Store deployment packages locally or in the S3 bucket.
 - [x] Support almost all features of Lambda resources (function, layer, alias, etc.)
 - [x] Lambda@Edge
@@ -150,6 +150,22 @@ module "lambda_function_existing_package_s3" {
     bucket = "my-bucket-with-lambda-builds"
     key    = aws_s3_bucket_object.my_function.id
   }
+}
+```
+
+### Lambda Functions from Container Image stored on AWS ECR
+
+```hcl
+module "lambda_function_container_image" {
+  source = "terraform-aws-modules/lambda/aws"
+
+  function_name = "my-lambda-existing-package-local"
+  description   = "My awesome lambda function"
+
+  create_package = false
+  
+  image_uri    = "132367819851.dkr.ecr.eu-west-1.amazonaws.com/complete-cow:1.0"
+  package_type = "Image"
 }
 ```
 
@@ -543,6 +559,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 ## Examples
 
 * [Complete](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/complete) - Create Lambda resources in various combinations with all supported features.
+* [Container Image](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/container-image) - Create Docker image (using [docker provider](https://registry.terraform.io/providers/kreuzwerker/docker)), push it to AWS ECR, and create Lambda function from it.
 * [Build and Package](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/build-package) - Build and create deployment packages in various ways.
 * [Alias](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/alias) - Create static and dynamic aliases in various ways.
 * [Deploy](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/deploy) - Complete end-to-end build/update/deploy process using AWS CodeDeploy.

--- a/README.md
+++ b/README.md
@@ -619,6 +619,11 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | function\_name | A unique name for your Lambda Function | `string` | `""` | no |
 | handler | Lambda Function entrypoint in your code | `string` | `""` | no |
 | hash\_extra | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
+| image\_uri | The ECR image URI containing the function's deployment package. | `string` | `null` | no |
+| image\_config\_entry_point | The ENTRYPOINT for the docker image. | `string` | `null` | no |
+| image\_config\_command | The CMD for the docker image. | `string` | `null` | no |
+| image\_config\_working_directory | The working directory for the docker image. | `string` | `null` | no |
+| package\_type | The Lambda deployment package type. | `string` | `Zip` | no |
 | kms\_key\_arn | The ARN of KMS key to use by your Lambda Function | `string` | `null` | no |
 | lambda\_at\_edge | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
 | lambda\_role | IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details. | `string` | `""` | no |

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -1,6 +1,6 @@
-# AWS Lambda with Container Image
+# AWS Lambda with EFS example
 
-Configuration in this directory creates AWS Lambda Function deployed with a Container Image.
+Configuration in this directory creates AWS Lambda Function deployed with Elastic File System (EFS) attached.
 
 ## Usage
 
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 3.19.0 |
+| aws | >= 2.67 |
 | random | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19.0 |
+| aws | >= 2.67 |
 | random | >= 2 |
 
 ## Inputs

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -1,6 +1,6 @@
-# AWS Lambda with EFS example
+# AWS Lambda launched from Docker Container Image example
 
-Configuration in this directory creates AWS Lambda Function deployed with Elastic File System (EFS) attached.
+Configuration in this directory creates AWS Lambda Function deployed with a Container Image.
 
 ## Usage
 

--- a/examples/container-image/context/Dockerfile
+++ b/examples/container-image/context/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY empty /empty

--- a/examples/container-image/context/empty
+++ b/examples/container-image/context/empty
@@ -1,0 +1,1 @@
+# empty file :)

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  # Make it faster by skipping something
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+module "lambda_function_with_container_image" {
+  source = "../../"
+
+  function_name = "${random_pet.this.id}-lambda-with-container"
+  description   = "My awesome lambda function"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  create_package = false
+
+  ######################
+  # Container Image
+  ######################
+
+  image_uri = "112233445566.dkr.ecr.eu-west-1.amazonaws.com/test-lambda:latest"
+  package_type = "Image"
+}

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -13,20 +13,53 @@ resource "random_pet" "this" {
   length = 2
 }
 
-module "lambda_function_with_container_image" {
+module "lambda_function_from_container_image" {
   source = "../../"
 
-  function_name = "${random_pet.this.id}-lambda-with-container"
-  description   = "My awesome lambda function"
-  handler       = "index.lambda_handler"
-  runtime       = "python3.8"
+  function_name = "${random_pet.this.id}-lambda-from-container-image"
+  description   = "My awesome lambda function from container image"
 
   create_package = false
 
-  ######################
+  ##################
   # Container Image
-  ######################
-
-  image_uri = "112233445566.dkr.ecr.eu-west-1.amazonaws.com/test-lambda:latest"
+  ##################
+  image_uri    = docker_registry_image.app.name
   package_type = "Image"
+}
+
+#################
+# ECR Repository
+#################
+resource "aws_ecr_repository" "this" {
+  name = random_pet.this.id
+}
+
+###############################################
+# Create Docker Image and push to ECR registry
+###############################################
+
+data "aws_caller_identity" "this" {}
+data "aws_region" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+locals {
+  ecr_address = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.name)
+  ecr_image = format("%v/%v:%v", local.ecr_address, aws_ecr_repository.this.id, "1.0")
+}
+
+provider "docker" {
+  registry_auth {
+    address  = local.ecr_address
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+resource "docker_registry_image" "app" {
+  name = local.ecr_image
+
+  build {
+    context = "context"
+  }
 }

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -45,7 +45,7 @@ data "aws_ecr_authorization_token" "token" {}
 
 locals {
   ecr_address = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.name)
-  ecr_image = format("%v/%v:%v", local.ecr_address, aws_ecr_repository.this.id, "1.0")
+  ecr_image   = format("%v/%v:%v", local.ecr_address, aws_ecr_repository.this.id, "1.0")
 }
 
 provider "docker" {

--- a/examples/container-image/outputs.tf
+++ b/examples/container-image/outputs.tf
@@ -1,88 +1,88 @@
 # Lambda Function
 output "this_lambda_function_arn" {
   description = "The ARN of the Lambda Function"
-  value       = module.lambda_function_with_container_image.this_lambda_function_arn
+  value       = module.lambda_function_from_container_image.this_lambda_function_arn
 }
 
 output "this_lambda_function_invoke_arn" {
   description = "The Invoke ARN of the Lambda Function"
-  value       = module.lambda_function_with_container_image.this_lambda_function_invoke_arn
+  value       = module.lambda_function_from_container_image.this_lambda_function_invoke_arn
 }
 
 output "this_lambda_function_name" {
   description = "The name of the Lambda Function"
-  value       = module.lambda_function_with_container_image.this_lambda_function_name
+  value       = module.lambda_function_from_container_image.this_lambda_function_name
 }
 
 output "this_lambda_function_qualified_arn" {
   description = "The ARN identifying your Lambda Function Version"
-  value       = module.lambda_function_with_container_image.this_lambda_function_qualified_arn
+  value       = module.lambda_function_from_container_image.this_lambda_function_qualified_arn
 }
 
 output "this_lambda_function_version" {
   description = "Latest published version of Lambda Function"
-  value       = module.lambda_function_with_container_image.this_lambda_function_version
+  value       = module.lambda_function_from_container_image.this_lambda_function_version
 }
 
 output "this_lambda_function_last_modified" {
   description = "The date Lambda Function resource was last modified"
-  value       = module.lambda_function_with_container_image.this_lambda_function_last_modified
+  value       = module.lambda_function_from_container_image.this_lambda_function_last_modified
 }
 
 output "this_lambda_function_kms_key_arn" {
   description = "The ARN for the KMS encryption key of Lambda Function"
-  value       = module.lambda_function_with_container_image.this_lambda_function_kms_key_arn
+  value       = module.lambda_function_from_container_image.this_lambda_function_kms_key_arn
 }
 
 output "this_lambda_function_source_code_hash" {
   description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
-  value       = module.lambda_function_with_container_image.this_lambda_function_source_code_hash
+  value       = module.lambda_function_from_container_image.this_lambda_function_source_code_hash
 }
 
 output "this_lambda_function_source_code_size" {
   description = "The size in bytes of the function .zip file"
-  value       = module.lambda_function_with_container_image.this_lambda_function_source_code_size
+  value       = module.lambda_function_from_container_image.this_lambda_function_source_code_size
 }
 
 # Lambda Layer
 output "this_lambda_layer_arn" {
   description = "The ARN of the Lambda Layer with version"
-  value       = module.lambda_function_with_container_image.this_lambda_layer_arn
+  value       = module.lambda_function_from_container_image.this_lambda_layer_arn
 }
 
 output "this_lambda_layer_layer_arn" {
   description = "The ARN of the Lambda Layer without version"
-  value       = module.lambda_function_with_container_image.this_lambda_layer_layer_arn
+  value       = module.lambda_function_from_container_image.this_lambda_layer_layer_arn
 }
 
 output "this_lambda_layer_created_date" {
   description = "The date Lambda Layer resource was created"
-  value       = module.lambda_function_with_container_image.this_lambda_layer_created_date
+  value       = module.lambda_function_from_container_image.this_lambda_layer_created_date
 }
 
 output "this_lambda_layer_source_code_size" {
   description = "The size in bytes of the Lambda Layer .zip file"
-  value       = module.lambda_function_with_container_image.this_lambda_layer_source_code_size
+  value       = module.lambda_function_from_container_image.this_lambda_layer_source_code_size
 }
 
 output "this_lambda_layer_version" {
   description = "The Lambda Layer version"
-  value       = module.lambda_function_with_container_image.this_lambda_layer_version
+  value       = module.lambda_function_from_container_image.this_lambda_layer_version
 }
 
 # IAM Role
 output "lambda_role_arn" {
   description = "The ARN of the IAM role created for the Lambda Function"
-  value       = module.lambda_function_with_container_image.lambda_role_arn
+  value       = module.lambda_function_from_container_image.lambda_role_arn
 }
 
 output "lambda_role_name" {
   description = "The name of the IAM role created for the Lambda Function"
-  value       = module.lambda_function_with_container_image.lambda_role_name
+  value       = module.lambda_function_from_container_image.lambda_role_name
 }
 
 # CloudWatch Log Group
 output "lambda_cloudwatch_log_group_arn" {
   description = "The ARN of the Cloudwatch Log Group"
-  value       = module.lambda_function_with_container_image.lambda_cloudwatch_log_group_arn
+  value       = module.lambda_function_from_container_image.lambda_cloudwatch_log_group_arn
 }

--- a/examples/container-image/outputs.tf
+++ b/examples/container-image/outputs.tf
@@ -1,0 +1,88 @@
+# Lambda Function
+output "this_lambda_function_arn" {
+  description = "The ARN of the Lambda Function"
+  value       = module.lambda_function_with_container_image.this_lambda_function_arn
+}
+
+output "this_lambda_function_invoke_arn" {
+  description = "The Invoke ARN of the Lambda Function"
+  value       = module.lambda_function_with_container_image.this_lambda_function_invoke_arn
+}
+
+output "this_lambda_function_name" {
+  description = "The name of the Lambda Function"
+  value       = module.lambda_function_with_container_image.this_lambda_function_name
+}
+
+output "this_lambda_function_qualified_arn" {
+  description = "The ARN identifying your Lambda Function Version"
+  value       = module.lambda_function_with_container_image.this_lambda_function_qualified_arn
+}
+
+output "this_lambda_function_version" {
+  description = "Latest published version of Lambda Function"
+  value       = module.lambda_function_with_container_image.this_lambda_function_version
+}
+
+output "this_lambda_function_last_modified" {
+  description = "The date Lambda Function resource was last modified"
+  value       = module.lambda_function_with_container_image.this_lambda_function_last_modified
+}
+
+output "this_lambda_function_kms_key_arn" {
+  description = "The ARN for the KMS encryption key of Lambda Function"
+  value       = module.lambda_function_with_container_image.this_lambda_function_kms_key_arn
+}
+
+output "this_lambda_function_source_code_hash" {
+  description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
+  value       = module.lambda_function_with_container_image.this_lambda_function_source_code_hash
+}
+
+output "this_lambda_function_source_code_size" {
+  description = "The size in bytes of the function .zip file"
+  value       = module.lambda_function_with_container_image.this_lambda_function_source_code_size
+}
+
+# Lambda Layer
+output "this_lambda_layer_arn" {
+  description = "The ARN of the Lambda Layer with version"
+  value       = module.lambda_function_with_container_image.this_lambda_layer_arn
+}
+
+output "this_lambda_layer_layer_arn" {
+  description = "The ARN of the Lambda Layer without version"
+  value       = module.lambda_function_with_container_image.this_lambda_layer_layer_arn
+}
+
+output "this_lambda_layer_created_date" {
+  description = "The date Lambda Layer resource was created"
+  value       = module.lambda_function_with_container_image.this_lambda_layer_created_date
+}
+
+output "this_lambda_layer_source_code_size" {
+  description = "The size in bytes of the Lambda Layer .zip file"
+  value       = module.lambda_function_with_container_image.this_lambda_layer_source_code_size
+}
+
+output "this_lambda_layer_version" {
+  description = "The Lambda Layer version"
+  value       = module.lambda_function_with_container_image.this_lambda_layer_version
+}
+
+# IAM Role
+output "lambda_role_arn" {
+  description = "The ARN of the IAM role created for the Lambda Function"
+  value       = module.lambda_function_with_container_image.lambda_role_arn
+}
+
+output "lambda_role_name" {
+  description = "The name of the IAM role created for the Lambda Function"
+  value       = module.lambda_function_with_container_image.lambda_role_name
+}
+
+# CloudWatch Log Group
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The ARN of the Cloudwatch Log Group"
+  value       = module.lambda_function_with_container_image.lambda_cloudwatch_log_group_arn
+}

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12.6"
+
+  required_providers {
+    aws    = ">= 2.67"
+    random = ">= 2"
+  }
+}

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -2,7 +2,12 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
+
+    docker = {
+      source = "kreuzwerker/docker"
+      version = ">= 2.8.0"
+    }
   }
 }

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2"
 
     docker = {
-      source = "kreuzwerker/docker"
+      source  = "kreuzwerker/docker"
       version = ">= 2.8.0"
     }
   }

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -1,6 +1,7 @@
-# AWS Lambda with Container Image
+# AWS Lambda with EFS Example
 
-Configuration in this directory creates AWS Lambda Function deployed with a Container Image.
+Configuration in this directory creates AWS Lambda Function deployed with Elastic File System (EFS) attached.
+
 
 ## Usage
 

--- a/examples/with-efs/versions.tf
+++ b/examples/with-efs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/examples/with-vpc/versions.tf
+++ b/examples/with-vpc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67"
+    aws    = ">= 3.19"
     random = ">= 2"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "aws_lambda_function" "this" {
   function_name                  = var.function_name
   description                    = var.description
   role                           = var.create_role ? aws_iam_role.lambda[0].arn : var.lambda_role
-  handler                        = var.handler
+  handler                        = var.package_type != "Zip" ? null : var.handler
   memory_size                    = var.memory_size
   reserved_concurrent_executions = var.reserved_concurrent_executions
-  runtime                        = var.runtime
+  runtime                        = var.package_type != "Zip" ? null : var.runtime
   layers                         = var.layers
   timeout                        = var.lambda_at_edge ? min(var.timeout, 5) : var.timeout
   publish                        = var.lambda_at_edge ? true : var.publish
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "this" {
   s3_object_version = local.s3_object_version
 
   dynamic "image_config" {
-    for_each = var.image_config_entry_point != null && var.image_config_command != null && var.image_config_working_directory != null ? [true] : []
+    for_each = length(var.image_config_entry_point) > 0 || length(var.image_config_command) > 0 || var.image_config_working_directory != null ? [true] : []
     content {
       entry_point       = var.image_config_entry_point
       command           = var.image_config_command

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,8 @@ resource "aws_lambda_function" "this" {
   timeout                        = var.lambda_at_edge ? min(var.timeout, 5) : var.timeout
   publish                        = var.lambda_at_edge ? true : var.publish
   kms_key_arn                    = var.kms_key_arn
+  image_uri                      = var.image_uri
+  package_type                   = var.package_type
 
   filename         = local.filename
   source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && ! local.was_missing ? filebase64sha256(local.filename) : null
@@ -32,6 +34,15 @@ resource "aws_lambda_function" "this" {
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key
   s3_object_version = local.s3_object_version
+
+  dynamic "image_config" {
+    for_each = var.image_config_entry_point != null && var.image_config_command != null && var.image_config_working_directory != null ? [true] : []
+    content {
+      entry_point       = var.image_config_entry_point
+      command           = var.image_config_command
+      working_directory = var.image_config_working_directory
+    }
+  }
 
   dynamic "environment" {
     for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.67"
+    aws    = ">= 3.19"
   }
 }

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.19"
+    aws = ">= 3.19"
   }
 }

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.19"
+    aws   = ">= 3.19"
     local = ">= 1"
     null  = ">= 2"
   }

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws   = ">= 2.67"
+    aws    = ">= 3.19"
     local = ">= 1"
     null  = ">= 2"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -151,30 +151,30 @@ variable "s3_object_tags" {
   default     = {}
 }
 
+variable "package_type" {
+  description = "The Lambda deployment package type. Valid options: Zip or Image"
+  type        = string
+  default     = "Zip"
+}
+
 variable "image_uri" {
   description = "The ECR image URI containing the function's deployment package."
   type        = string
   default     = null
 }
 
-variable "package_type" {
-  description = "The Lambda deployment package type."
-  type        = string
-  default     = "Zip"
-}
-
 variable "image_config_entry_point" {
   description = "The ENTRYPOINT for the docker image"
-  type        = string
-  default     = null
+  type        = list(string)
+  default     = []
 
 }
 variable "image_config_command" {
   description = "The CMD for the docker image"
-  type        = string
-  default     = null
-
+  type        = list(string)
+  default     = []
 }
+
 variable "image_config_working_directory" {
   description = "The working directory for the docker image"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,36 @@ variable "s3_object_tags" {
   default     = {}
 }
 
+variable "image_uri" {
+  description = "The ECR image URI containing the function's deployment package."
+  type        = string
+  default     = null
+}
+
+variable "package_type" {
+  description = "The Lambda deployment package type."
+  type        = string
+  default     = "Zip"
+}
+
+variable "image_config_entry_point" {
+  description = "The ENTRYPOINT for the docker image"
+  type        = string
+  default     = null
+
+}
+variable "image_config_command" {
+  description = "The CMD for the docker image"
+  type        = string
+  default     = null
+
+}
+variable "image_config_working_directory" {
+  description = "The working directory for the docker image"
+  type        = string
+  default     = null
+}
+
 ########
 # Layer
 ########

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws      = ">= 2.67"
+    aws    = ">= 3.19"
     external = ">= 1"
     local    = ">= 1"
     random   = ">= 2"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.19"
+    aws      = ">= 3.19"
     external = ">= 1"
     local    = ">= 1"
     random   = ">= 2"


### PR DESCRIPTION
## Description
Resolves #79

## Motivation and Context

- AWS has recently [announced support for container images](https://aws.amazon.com/blogs/aws/new-for-aws-lambda-container-image-support/) 
- [v3.19.0+](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.19.0) of the AWS Provider for terraform already [supports it](https://github.com/hashicorp/terraform-provider-aws/pull/16512). 

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- Tested on a project that uses container image.
- Tested the example added in this PR 
- Tested Plan & Apply. Works as expected.
	```
	Terraform v0.13.5
	+ provider registry.terraform.io/hashicorp/aws v3.19.0
	+ provider registry.terraform.io/hashicorp/external v2.0.0
	+ provider registry.terraform.io/hashicorp/local v2.0.0
	+ provider registry.terraform.io/hashicorp/null v3.0.0
	+ provider registry.terraform.io/hashicorp/random v3.0.0
	```
