### PR TITLE
fix: skip creating deployments if current and target versions match

### DIFF
--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -34,7 +34,7 @@ locals {
   script = <<EOF
 #!/bin/bash
 
-if [[ "${var.target_version}" == "${var.current_version != "" ? var.current_version : local.current_version}" ]]; then
+if [[ '${var.target_version}' == '${var.current_version != "" ? var.current_version : local.current_version}' ]]; then
   echo "Skipping deployment because target version (${var.target_version}) is already the current version"
   exit 0
 fi

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -33,6 +33,12 @@ locals {
 
   script = <<EOF
 #!/bin/bash
+
+if [[ "${var.target_version}" == "${var.current_version != "" ? var.current_version : local.current_version}" ]]; then
+  echo "Skipping deployment because target version (${var.target_version}) is already the current version"
+  exit 0
+fi
+
 ID=$(${var.aws_cli_command} deploy create-deployment \
     --application-name ${local.app_name} \
     --deployment-group-name ${local.deployment_group_name} \


### PR DESCRIPTION
It appears AWS CodeDeploy will reject deployments where the CurrentVersion and TargetVersion match (edit: if the deployment config is anything other than all-at-once, e.g. canary or linear rollout). We avoid creating such a failing deployment by ignoring cases where the current and target versions already match in the deploy script.

Fixes #82, where there's a lot more detail on the motivation here.