### PR TITLE
docs: Improved package.py error message for missing source_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ terraform apply
 
 ## <a name="build"></a> Build Dependencies
 
-You can specify `source_path` in a variety of ways to achieve desired flexibility when building deployment packages locally or in Docker. You can use absolute or relative paths.
+You can specify `source_path` in a variety of ways to achieve desired flexibility when building deployment packages locally or in Docker. You can use absolute or relative paths.  If you have placed terraform files in subdirectories, note that relative paths are specified from the directory where `terraform plan` is run and not the location of your terraform file. 
 
 Note that, when building locally, files are not copying anywhere from the source directories when making packages, we use fast Python regular expressions to find matching files and directories, which makes packaging very fast and easy to understand.
 

--- a/package.py
+++ b/package.py
@@ -698,7 +698,7 @@ class BuildPlanManager:
             if isinstance(claim, str):
                 path = claim
                 if not os.path.exists(path):
-                    abort('source_path must be set.')
+                    abort('Could not locate source_path "{path}".  Paths are relative to directory where `terraform plan` is being run.'.format(path=path))
                 runtime = query.runtime
                 if runtime.startswith('python'):
                     pip_requirements_step(

--- a/package.py
+++ b/package.py
@@ -698,7 +698,10 @@ class BuildPlanManager:
             if isinstance(claim, str):
                 path = claim
                 if not os.path.exists(path):
-                    abort('Could not locate source_path "{path}".  Paths are relative to directory where `terraform plan` is being run.'.format(path=path))
+                    abort('Could not locate source_path "{path}".  Paths are relative to directory where `terraform plan` is being run ("{pwd}")'.format(
+                        path=path,
+                        pwd=os.getcwd()
+                    ))
                 runtime = query.runtime
                 if runtime.startswith('python'):
                     pip_requirements_step(


### PR DESCRIPTION
## Description
Changed the wording and included the failing `source_path` when it can't be found.  Added explanation to both the error message and the README.md regarding how relative paths are interpreted.

## Motivation and Context
I spent 30 minutes trying to interpret "source_path must be set" when it was set, but its relativity was wrong.

## Breaking Changes
None.

## How Has This Been Tested?
Manual testing with valid and invalid paths.  This is my first time using the module, so I don't have a complex source_path, so complex source_paths aren't tested.
