### PR TITLE
docs: Explicitly state the IAM role property used for lambda_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | package\_type | The Lambda deployment package type. | `string` | `Zip` | no |
 | kms\_key\_arn | The ARN of KMS key to use by your Lambda Function | `string` | `null` | no |
 | lambda\_at\_edge | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
-| lambda\_role | IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details. | `string` | `""` | no |
+| lambda\_role | IAM role ARN attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details. | `string` | `""` | no |
 | layer\_name | Name of Lambda Layer to create | `string` | `""` | no |
 | layers | List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. | `list(string)` | `null` | no |
 | license\_info | License info for your Lambda Layer. Eg, MIT or full url of a license. | `string` | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "runtime" {
 }
 
 variable "lambda_role" {
-  description = " IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details."
+  description = " IAM role ARN attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Description
Minor change to README to indicate the IAM role ARN should be used when using lambda_role

## Motivation and Context
Since the only requirement is a string, you could pass the IAM role name, or other string type properties.
The error on apply (ValidationException) isn't inherently descript enough to know exactly what was wrong.

## Breaking Changes
none

## How Has This Been Tested?
Reviewed Markdown