### PR TITLE
feat: Added interpreter variable to control script runtime

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = distinct(concat(slice(list("lambda.amazonaws.com", "edgelambda.amazonaws.com"), 0, var.lambda_at_edge ? 2 : 1), var.trusted_entities))
+      identifiers = distinct(concat(slice(["lambda.amazonaws.com", "edgelambda.amazonaws.com"], 0, var.lambda_at_edge ? 2 : 1), var.trusted_entities))
     }
   }
 }

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -160,7 +160,7 @@ No Modules.
 | description | Description to use for the deployment | `string` | `""` | no |
 | force\_deploy | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
 | function\_name | The name of the Lambda function to deploy | `string` | `""` | no |
-| interpreter | The interpreter used to execute deploy script | `list(string)` | `["/bin/bash", "-c]` | no |
+| interpreter | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br>  "/bin/bash",<br>  "-c"<br>]</pre> | no |
 | save\_deploy\_script | Save deploy script locally | `bool` | `false` | no |
 | target\_version | Target version of Lambda function version to deploy | `string` | `""` | no |
 | triggers | Map of triggers which will be notified when event happens. Valid options for event types are DeploymentStart, DeploymentSuccess, DeploymentFailure, DeploymentStop, DeploymentRollback, DeploymentReady (Applies only to replacement instances in a blue/green deployment), InstanceStart, InstanceSuccess, InstanceFailure, InstanceReady. Note that not all are applicable for Lambda deployments. | `map(any)` | `{}` | no |

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -140,6 +140,7 @@ module "lambda" {
 | description | Description to use for the deployment | `string` | `""` | no |
 | force\_deploy | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
 | function\_name | The name of the Lambda function to deploy | `string` | `""` | no |
+| interpreter | The interpreter used to execute deploy script | `list(string)` | `["/bin/bash", "-c]` | no |
 | save\_deploy\_script | Save deploy script locally | `bool` | `false` | no |
 | target\_version | Target version of Lambda function version to deploy | `string` | `""` | no |
 | triggers | Map of triggers which will be notified when event happens. Valid options for event types are DeploymentStart, DeploymentSuccess, DeploymentFailure, DeploymentStop, DeploymentRollback, DeploymentReady (Applies only to replacement instances in a blue/green deployment), InstanceStart, InstanceSuccess, InstanceFailure, InstanceReady. Note that not all are applicable for Lambda deployments. | `map(any)` | `{}` | no |

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -107,7 +107,8 @@ resource "null_resource" "deploy" {
   }
 
   provisioner "local-exec" {
-    command = local.script
+    command     = local.script
+    interpreter = var.interpreter
   }
 }
 

--- a/modules/deploy/variables.tf
+++ b/modules/deploy/variables.tf
@@ -41,7 +41,7 @@ variable "after_allow_traffic_hook_arn" {
 }
 
 variable "interpreter" {
-  description = "list of interpreter arguments used to execute deploy script, first arg is path"
+  description = "List of interpreter arguments used to execute deploy script, first arg is path"
   type        = list(string)
   default     = ["/bin/bash", "-c"]
 }

--- a/modules/deploy/variables.tf
+++ b/modules/deploy/variables.tf
@@ -40,6 +40,12 @@ variable "after_allow_traffic_hook_arn" {
   default     = ""
 }
 
+variable "interpreter" {
+  description = "list of interpreter arguments used to execute deploy script, first arg is path"
+  type        = list(string)
+  default     = ["/bin/bash", "-c"]
+}
+
 variable "description" {
   description = "Description to use for the deployment"
   type        = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -121,5 +121,9 @@ output "local_filename" {
 
 output "s3_object" {
   description = "The map with S3 object data of zip archive deployed (if deployment was from S3)"
-  value       = map("bucket", local.s3_bucket, "key", local.s3_key, "version_id", local.s3_object_version)
+  value       = {
+    bucket = local.s3_bucket
+    key = local.s3_key
+    version_id = local.s3_object_version
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -121,9 +121,9 @@ output "local_filename" {
 
 output "s3_object" {
   description = "The map with S3 object data of zip archive deployed (if deployment was from S3)"
-  value       = {
-    bucket = local.s3_bucket
-    key = local.s3_key
+  value = {
+    bucket     = local.s3_bucket
+    key        = local.s3_key
     version_id = local.s3_object_version
   }
 }


### PR DESCRIPTION
## Description
Include `interpreter` argument of `provisioner.local_exec` block as variable in `null_resource.deploy`.  Allow user to control the execution runtime of the deploy script.

## Motivation and Context
`/bin/bash` isn't necessarily guaranteed to be the selected shell, leading to failures in bash built-in control flow.  
See issue <>


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
