### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,34 @@
-.terraform
-*.tfstate.backup
-*.tfstate
-*.tfvars
-*.tfplan
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
 .terraform.lock.hcl
 
-builds/
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.tfplan
 
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Lambda directories
+builds/
 __pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -596,8 +596,8 @@ No Modules.
 | Name |
 |------|
 | [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/arn) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/cloudwatch_log_group) |
 | [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/cloudwatch_log_group) |
 | [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy) |
 | [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy) |
 | [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy_attachment) |

--- a/README.md
+++ b/README.md
@@ -587,6 +587,34 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | local | >= 1 |
 | null | >= 2 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/arn) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/cloudwatch_log_group) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy) |
+| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy_attachment) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role_policy_attachment) |
+| [aws_lambda_event_source_mapping](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_event_source_mapping) |
+| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function) |
+| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function_event_invoke_config) |
+| [aws_lambda_layer_version](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_layer_version) |
+| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_permission) |
+| [aws_lambda_provisioned_concurrency_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_provisioned_concurrency_config) |
+| [aws_s3_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/s3_bucket_object) |
+| [external_external](https://registry.terraform.io/providers/hashicorp/external/1/docs/data-sources/external) |
+| [local_file](https://registry.terraform.io/providers/hashicorp/local/1/docs/resources/file) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -707,7 +735,6 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -29,6 +29,21 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| alias_existing | ../../modules/alias |  |
+| alias_no_refresh | ../../modules/alias |  |
+| alias_refresh | ../../modules/alias |  |
+| lambda_function | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -60,5 +75,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -30,6 +30,20 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 3.19 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sns_topic) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -57,5 +71,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -29,6 +29,27 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function_from_package | ../../ |  |
+| lambda_layer | ../../ |  |
+| package_dir | ../../ |  |
+| package_dir_without_pip_install | ../../ |  |
+| package_file | ../../ |  |
+| package_file_with_pip_requirements | ../../ |  |
+| package_with_commands_and_patterns | ../../ |  |
+| package_with_docker | ../../ |  |
+| package_with_patterns | ../../ |  |
+| package_with_pip_requirements_in_docker | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -36,5 +57,4 @@ No input.
 ## Outputs
 
 No output.
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -31,6 +31,26 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 2.67 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| disabled_lambda | ../../ |  |
+| lambda_at_edge | ../../ |  |
+| lambda_function | ../../ |  |
+| lambda_function_existing_package_local | ../../ |  |
+| lambda_layer_local | ../../ |  |
+| lambda_layer_s3 | ../../ |  |
+| lambda_with_provisioned_concurrency | ../../ |  |
+| s3_bucket | terraform-aws-modules/s3-bucket/aws |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/2.67/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -58,5 +78,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -32,6 +32,23 @@ Note that this example may create resources which cost money. Run `terraform des
 | docker | >= 2.8.0 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function_from_container_image | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/caller_identity) |
+| [aws_ecr_authorization_token](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/ecr_authorization_token) |
+| [aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/ecr_repository) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/region) |
+| [docker_registry_image](https://registry.terraform.io/providers/kreuzwerker/docker/2.8.0/docs/resources/registry_image) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -57,5 +74,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -30,6 +30,21 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 3.19 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| alias_refresh | ../../modules/alias |  |
+| deploy | ../../modules/deploy |  |
+| lambda_function | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sns_topic) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -47,5 +62,4 @@ No input.
 | codedeploy\_iam\_role\_name | Name of IAM role used by CodeDeploy |
 | deploy\_script | Path to a deployment script |
 | script | Deployment script |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -32,6 +32,20 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws.us-east-1 | >= 3.19 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function | ../../ |  |
+| lambda_function_another_region | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -59,5 +73,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -29,6 +29,18 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -56,5 +68,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -31,6 +31,22 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 3.19 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function_with_efs | ../../ |  |
+| vpc | terraform-aws-modules/vpc/aws |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_efs_access_point](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/efs_access_point) |
+| [aws_efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/efs_file_system) |
+| [aws_efs_mount_target](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/efs_mount_target) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -58,5 +74,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -31,6 +31,19 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| lambda_function_in_vpc | ../../ |  |
+| vpc | terraform-aws-modules/vpc/aws |  |
+
+## Resources
+
+| Name |
+|------|
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -58,5 +71,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -124,6 +124,19 @@ module "lambda" {
 |------|---------|
 | aws | >= 3.19 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_alias) |
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_alias) |
+| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function_event_invoke_config) |
+| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_permission) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -156,7 +169,6 @@ module "lambda" {
 | this\_lambda\_alias\_function\_version | Lambda function version which the alias uses |
 | this\_lambda\_alias\_invoke\_arn | The ARN to be used for invoking Lambda Function from API Gateway |
 | this\_lambda\_alias\_name | The name of the Lambda Function Alias |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -132,8 +132,8 @@ No Modules.
 
 | Name |
 |------|
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_alias) |
 | [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_alias) |
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_alias) |
 | [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function_event_invoke_config) |
 | [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_permission) |
 

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -112,6 +112,26 @@ module "lambda" {
 | local | >= 1 |
 | null | >= 2 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_codedeploy_app](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/codedeploy_app) |
+| [aws_codedeploy_deployment_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/codedeploy_deployment_group) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role_policy_attachment) |
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_alias) |
+| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_function) |
+| [local_file](https://registry.terraform.io/providers/hashicorp/local/1/docs/resources/file) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -160,7 +180,6 @@ module "lambda" {
 | codedeploy\_iam\_role\_name | Name of IAM role used by CodeDeploy |
 | deploy\_script | Path to a deployment script |
 | script | Deployment script |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
