### PR TITLE
feat: Add output for lambda CloudWatch log group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | Name | Description |
 |------|-------------|
 | lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
+| lambda\_cloudwatch\_log\_group\_name | The name of the Cloudwatch Log Group |
 | lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
 | lambda\_role\_name | The name of the IAM role created for the Lambda Function |
 | local\_filename | The filename of zip archive deployed (if deployment was from local) |

--- a/iam.tf
+++ b/iam.tf
@@ -4,6 +4,7 @@ locals {
   # Lambda@Edge uses the Cloudwatch region closest to the location where the function is executed
   # The region part of the LogGroup ARN is then replaced with a wildcard (*) so Lambda@Edge is able to log in every region
   log_group_arn_regional = element(concat(data.aws_cloudwatch_log_group.lambda.*.arn, aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
+  log_group_name         = element(concat(data.aws_cloudwatch_log_group.lambda.*.name, aws_cloudwatch_log_group.lambda.*.name, [""]), 0)
   log_group_arn          = local.create_role && var.lambda_at_edge ? format("arn:%s:%s:%s:%s:%s", data.aws_arn.log_group_arn[0].partition, data.aws_arn.log_group_arn[0].service, "*", data.aws_arn.log_group_arn[0].account, data.aws_arn.log_group_arn[0].resource) : local.log_group_arn_regional
 
   role_name = local.create_role ? coalesce(var.role_name, var.function_name) : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -107,6 +107,11 @@ output "lambda_cloudwatch_log_group_arn" {
   description = "The ARN of the Cloudwatch Log Group"
   value       = local.log_group_arn
 }
+  
+output "lambda_cloudwatch_log_group_name" {
+  description = "The name of the Cloudwatch Log Group"
+  value       = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
+}
 
 # Deployment package
 output "local_filename" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -110,7 +110,7 @@ output "lambda_cloudwatch_log_group_arn" {
   
 output "lambda_cloudwatch_log_group_name" {
   description = "The name of the Cloudwatch Log Group"
-  value       = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
+  value       = local.log_group_name
 }
 
 # Deployment package


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
New output for the log group name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #110 
I need the log group name for a metric filter resource.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Can see the output value.