### PR TITLE
chore: only run validate check on min terraform version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Execute pre-commit
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.minVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure terraform_validate
+        run: pre-commit run --color=always --show-diff-on-failure --all-files terraform_validate
 
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,4 +52,11 @@ jobs:
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
 
       - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.minVersion }}
+        run: pre-commit run --color=always --show-diff-on-failure terraform_validate
+
+      - name: Execute pre-commit
+        # Run all pre-commit checks on max version supported
+        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
         run: pre-commit run --color=always --show-diff-on-failure --all-files

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | external | >= 1 |
 | local | >= 1 |

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | external | >= 1 |
 | local | >= 1 |

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.67 |
 | random | >= 2 |
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 2.67 |
 | random | >= 2 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 2.67"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 2.67"

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | docker | >= 2.8.0 |
 | random | >= 2 |

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | docker | >= 2.8.0 |
 | random | >= 2 |

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.27"

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.27"

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/with-efs/versions.tf
+++ b/examples/with-efs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/with-efs/versions.tf
+++ b/examples/with-efs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/with-vpc/versions.tf
+++ b/examples/with-vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/with-vpc/versions.tf
+++ b/examples/with-vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -115,7 +115,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 
 ## Providers

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -115,7 +115,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 
 ## Providers

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = ">= 3.19"

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 3.19"

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -99,7 +99,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13 |
 | aws | >= 3.19 |
 | local | >= 1 |
 | null | >= 2 |

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -99,7 +99,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | local | >= 1 |
 | null | >= 2 |

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws   = ">= 3.19"

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws   = ">= 3.19"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
     aws      = ">= 3.19"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws      = ">= 3.19"


### PR DESCRIPTION
## Description
- only run validate check on min terraform version

## Motivation and Context
- we will use max version supported to run all pre-commit checks, but only perform validation on min supported version

## Breaking Changes
- no

## How Has This Been Tested?
- static checks
