### PR TITLE
fix: add documentation for the :zip command. fixes #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,10 @@ source_path = [
     ]
   }, {
     path     = "src/python3.8-app3",
-    commands = ["npm install"],
+    commands = [
+      "npm install",
+      ":zip"
+    ],
     patterns = [
       "!.*/.*\\.txt",    # Skip all txt files recursively
       "node_modules/.+", # Include all node_modules
@@ -424,6 +427,7 @@ Few notes:
 ```
 
 * `commands` - List of commands to run. If specified, this argument overrides `pip_requirements`.
+  * `:zip [source] [destination]` is a special command which creates content of current working directory (first argument) and places it inside of path (second argument).
 * `pip_requirements` - Controls whether to execute `pip install`. Set to `false` to disable this feature, `true` to run `pip install` with `requirements.txt` found in `path`. Or set to another filename which you want to use instead.
 * `prefix_in_zip` - If specified, will be used as a prefix inside zip-archive. By default, everything installs into the root of zip-archive.
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -255,7 +255,10 @@ module "lambda_function" {
   #    },
   #    {
   #      path = "${path.module}/../fixtures/python3.8-app1"
-  #      commands = ["npm install"]
+  #      commands = [
+  #        "npm install",
+  #        ":zip"
+  #      ]
   #      prefix_in_zip = "foo/bar",
   #      patterns = [
   #        "!.*/.*\\.txt", # Filter all txt files recursively
@@ -264,7 +267,10 @@ module "lambda_function" {
   #    },
   #    {
   #      path = "${path.module}/../fixtures/python3.8-app1"
-  #      commands = ["npm install"]
+  #      commands = [
+  #        "npm install",
+  #        ":zip"
+  #      ]
   #      prefix_in_zip = "foo/bar", # By default everything installs into the root of a zip package
   #      patterns = <<END
   #        !.*/.*\.txt       # Filter all txt files recursively
@@ -281,7 +287,10 @@ module "lambda_function" {
   #    },
   #    {
   #      path = "${path.module}/../fixtures/python3.8-app1"
-  #      commands = ["npm install"]
+  #      commands = [
+  #        "npm install",
+  #        ":zip"
+  #      ]
   #      prefix_in_zip = "foo/bar",
   #      patterns = [".*"]  # default
   #    }


### PR DESCRIPTION
## Description
From reviewing #62 I discovered the solution for the error mentioned in that issue has been found but not yet documented for future users. This change is intended to begin documenting the special `:zip` command so future module users do not end up confused why they are getting a Python error from what appears to be a properly configured module usage.

## Motivation and Context
This fixes the documentation issue discovered in #62.

## Breaking Changes
This is a documentation change only, no breaking changes.

## How Has This Been Tested?
Documentation change, no testing.