### PR TITLE
chore: fix documentation due to terraform docs 0.11.2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,25 +595,25 @@ No Modules.
 
 | Name |
 |------|
-| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/arn) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/cloudwatch_log_group) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/cloudwatch_log_group) |
-| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy_attachment) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy_document) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role_policy_attachment) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role) |
-| [aws_lambda_event_source_mapping](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_event_source_mapping) |
-| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function_event_invoke_config) |
-| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function) |
-| [aws_lambda_layer_version](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_layer_version) |
-| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_permission) |
-| [aws_lambda_provisioned_concurrency_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_provisioned_concurrency_config) |
-| [aws_s3_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/s3_bucket_object) |
-| [external_external](https://registry.terraform.io/providers/hashicorp/external/1/docs/data-sources/external) |
-| [local_file](https://registry.terraform.io/providers/hashicorp/local/1/docs/resources/file) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
+| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_lambda_event_source_mapping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) |
+| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) |
+| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) |
+| [aws_lambda_layer_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) |
+| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) |
+| [aws_lambda_provisioned_concurrency_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_provisioned_concurrency_config) |
+| [aws_s3_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) |
+| [external_external](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) |
+| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
 
 ## Inputs
 

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -42,7 +42,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -40,9 +40,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sns_topic) |
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -48,7 +48,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -48,8 +48,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/2.67/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -42,12 +42,12 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/caller_identity) |
-| [aws_ecr_authorization_token](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/ecr_authorization_token) |
-| [aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/ecr_repository) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/region) |
-| [docker_registry_image](https://registry.terraform.io/providers/kreuzwerker/docker/2.8.0/docs/resources/registry_image) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_ecr_authorization_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_authorization_token) |
+| [aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [docker_registry_image](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -42,8 +42,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sns_topic) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -43,8 +43,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -39,7 +39,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -42,10 +42,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_efs_access_point](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/efs_access_point) |
-| [aws_efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/efs_file_system) |
-| [aws_efs_mount_target](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/efs_mount_target) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [aws_efs_access_point](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) |
+| [aws_efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) |
+| [aws_efs_mount_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -42,7 +42,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -132,10 +132,10 @@ No Modules.
 
 | Name |
 |------|
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_alias) |
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_alias) |
-| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_function_event_invoke_config) |
-| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/lambda_permission) |
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_alias) |
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) |
+| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) |
+| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) |
 
 ## Inputs
 

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -120,17 +120,17 @@ No Modules.
 
 | Name |
 |------|
-| [aws_codedeploy_app](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/codedeploy_app) |
-| [aws_codedeploy_deployment_group](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/codedeploy_deployment_group) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_policy_document) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_policy) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role_policy_attachment) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/iam_role) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/resources/iam_role) |
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_alias) |
-| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/3.19/docs/data-sources/lambda_function) |
-| [local_file](https://registry.terraform.io/providers/hashicorp/local/1/docs/resources/file) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
+| [aws_codedeploy_app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app) |
+| [aws_codedeploy_deployment_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_alias) |
+| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_function) |
+| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
 
 ## Inputs
 


### PR DESCRIPTION
## Description
- fix documentation due to terraform docs 0.11.2 update

## Motivation and Context
- current ci-cd checks are failing for users to do this update/change

## Breaking Changes
- no

## How Has This Been Tested?
- static ci-cd checks
