### PR TITLE
fix: revert module Terraform 0.13.x version upgrade 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,14 +7,65 @@ on:
       - master
 
 jobs:
-  getBaseVersion:
-    name: Get min/max versions
-    runs-on: ubuntu-latest
+# Min Terraform version(s)
+  getDirectories:
+      name: Get root directories
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v2
+          - name: Install Python
+            uses: actions/setup-python@v2
+          - name: Build matrix
+            id: matrix
+            run: |
+              DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
+              echo "::set-output name=directories::$DIRS"
+      outputs:
+          directories: ${{ steps.matrix.outputs.directories }}
 
+  preCommitMinVersions:
+    name: Min TF validate
+    needs: getDirectories
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v1.0.1
+        with:
+          directory: ${{ matrix.directory }}
+      - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ steps.minMax.outputs.minVersion }}
+      - name: Install pre-commit dependencies
+        run: pip install pre-commit
+      - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory !=  '.' }}
+        run:
+          pre-commit run terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*
+      - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory ==  '.' }}
+        run:
+          pre-commit run terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)
 
+
+# Max Terraform version
+  getBaseVersion:
+    name: Module max TF version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Terraform min/max versions
         id: minMax
         uses: clowdhaus/terraform-min-max@v1.0.1
@@ -22,40 +73,29 @@ jobs:
       minVersion: ${{ steps.minMax.outputs.minVersion }}
       maxVersion: ${{ steps.minMax.outputs.maxVersion }}
 
-  preCommit:
-    name: Pre-commit check
+  preCommitMaxVersion:
+    name: Max TF pre-commit
     runs-on: ubuntu-latest
     needs: getBaseVersion
     strategy:
       fail-fast: false
       matrix:
         version:
-          - ${{ needs.getBaseVersion.outputs.minVersion }}
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Install Python
         uses: actions/setup-python@v2
-
       - name: Install Terraform v${{ matrix.version }}
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ matrix.version }}
-
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-
-      - name: Execute pre-commit
-        # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.minVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure --all-files terraform_validate
-
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | external | >= 1 |
 | local | >= 1 |

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.67 |
 | random | >= 2 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 2.67"

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.27"

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | random | >= 2 |
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 3.19"

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -115,7 +115,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 
 ## Providers

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 3.19"

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -99,7 +99,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 0.12.26 |
 | aws | >= 3.19 |
 | local | >= 1 |
 | null | >= 2 |

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws   = ">= 3.19"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws      = ">= 3.19"


### PR DESCRIPTION
## Description
- revert module Terraform 0.13.x version upgrade
- update ci-cd checks to validate each Terraform root directory 

## Motivation and Context
- min version used will vary greatly, this update allows examples to have various minimum versions of Terraform and still be tested separate from what the module min version is itself

## Breaking Changes
- No

## How Has This Been Tested?
- CI/CD checks
