### PR TITLE
feat: Add s3_acl and s3_server_site_encryption variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| acl | (Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant` | `string` | `"private"` | no |
 | allowed\_triggers | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
 | artifacts\_dir | Directory name where artifacts should be stored | `string` | `"builds"` | no |
 | attach\_async\_event\_policy | Controls whether async event policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
@@ -698,6 +699,7 @@ No Modules.
 | s3\_existing\_package | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | s3\_object\_storage\_class | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
 | s3\_object\_tags | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |
+| server\_side\_encryption | Map containing server-side encryption configuration. | `string` | `null` | no |
 | source\_path | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | store\_on\_s3 | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
 | tags | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| acl | (Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant` | `string` | `"private"` | no |
+| s3\_acl | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
 | allowed\_triggers | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
 | artifacts\_dir | Directory name where artifacts should be stored | `string` | `"builds"` | no |
 | attach\_async\_event\_policy | Controls whether async event policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
@@ -699,7 +699,7 @@ No Modules.
 | s3\_existing\_package | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | s3\_object\_storage\_class | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
 | s3\_object\_tags | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |
-| server\_side\_encryption | Map containing server-side encryption configuration. | `string` | `null` | no |
+| s3\_server\_side\_encryption | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
 | source\_path | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | store\_on\_s3 | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
 | tags | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -619,7 +619,6 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| s3\_acl | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
 | allowed\_triggers | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
 | artifacts\_dir | Directory name where artifacts should be stored | `string` | `"builds"` | no |
 | attach\_async\_event\_policy | Controls whether async event policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
@@ -695,6 +694,7 @@ No Modules.
 | role\_permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function | `string` | `null` | no |
 | role\_tags | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | runtime | Lambda Function runtime | `string` | `""` | no |
+| s3\_acl | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
 | s3\_bucket | S3 bucket to store artifacts | `string` | `null` | no |
 | s3\_existing\_package | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | s3\_object\_storage\_class | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |

--- a/main.tf
+++ b/main.tf
@@ -109,13 +109,13 @@ resource "aws_s3_bucket_object" "lambda_package" {
   count = var.create && var.store_on_s3 && var.create_package ? 1 : 0
 
   bucket        = var.s3_bucket
-  acl           = var.acl
+  acl           = var.s3_acl
   key           = data.external.archive_prepare[0].result.filename
   source        = data.external.archive_prepare[0].result.filename
   etag          = fileexists(data.external.archive_prepare[0].result.filename) ? filemd5(data.external.archive_prepare[0].result.filename) : null
   storage_class = var.s3_object_storage_class
 
-  server_side_encryption = var.server_side_encryption
+  server_side_encryption = var.s3_server_side_encryption
 
   tags = merge(var.tags, var.s3_object_tags)
 

--- a/main.tf
+++ b/main.tf
@@ -109,10 +109,13 @@ resource "aws_s3_bucket_object" "lambda_package" {
   count = var.create && var.store_on_s3 && var.create_package ? 1 : 0
 
   bucket        = var.s3_bucket
+  acl           = var.acl
   key           = data.external.archive_prepare[0].result.filename
   source        = data.external.archive_prepare[0].result.filename
   etag          = fileexists(data.external.archive_prepare[0].result.filename) ? filemd5(data.external.archive_prepare[0].result.filename) : null
   storage_class = var.s3_object_storage_class
+  
+  server_side_encryption = var.server_side_encryption
 
   tags = merge(var.tags, var.s3_object_tags)
 

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_s3_bucket_object" "lambda_package" {
   source        = data.external.archive_prepare[0].result.filename
   etag          = fileexists(data.external.archive_prepare[0].result.filename) ? filemd5(data.external.archive_prepare[0].result.filename) : null
   storage_class = var.s3_object_storage_class
-  
+
   server_side_encryption = var.server_side_encryption
 
   tags = merge(var.tags, var.s3_object_tags)

--- a/variables.tf
+++ b/variables.tf
@@ -523,17 +523,18 @@ variable "s3_bucket" {
   default     = null
 }
 
-variable "acl" {
-  description = "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`"
+variable "s3_acl" {
+  description = "The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private."
   type        = string
   default     = "private"
 }
 
-variable "server_side_encryption" {
-  description = "Map containing server-side encryption configuration."
+variable "s3_server_side_encryption" {
+  description = "Specifies server-side encryption of the object in S3. Valid values are \"AES256\" and \"aws:kms\"."
   type        = string
   default     = null
 }
+
 variable "source_path" {
   description = "The absolute path to a local file or directory containing your Lambda source code"
   type        = any # string | list(string | map(any))

--- a/variables.tf
+++ b/variables.tf
@@ -523,6 +523,17 @@ variable "s3_bucket" {
   default     = null
 }
 
+variable "acl" {
+  description = "(Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant`"
+  type        = string
+  default     = "private"
+}
+
+variable "server_side_encryption" {
+  description = "Map containing server-side encryption configuration."
+  type        = string
+  default     = null
+}
 variable "source_path" {
   description = "The absolute path to a local file or directory containing your Lambda source code"
   type        = any # string | list(string | map(any))


### PR DESCRIPTION
## Description
adding variable acl and server_site_encryption for s3_bucket_object resource

## Motivation and Context
my bucket where I keep lambda code is encrypted and has different acl

## Breaking Changes
nope

## How Has This Been Tested?
on internal dev env