### PR TITLE
fix: Defaults the role_name coalesce to * to workaround import error

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -7,7 +7,11 @@ locals {
   log_group_name         = element(concat(data.aws_cloudwatch_log_group.lambda.*.name, aws_cloudwatch_log_group.lambda.*.name, [""]), 0)
   log_group_arn          = local.create_role && var.lambda_at_edge ? format("arn:%s:%s:%s:%s:%s", data.aws_arn.log_group_arn[0].partition, data.aws_arn.log_group_arn[0].service, "*", data.aws_arn.log_group_arn[0].account, data.aws_arn.log_group_arn[0].resource) : local.log_group_arn_regional
 
-  role_name = local.create_role ? coalesce(var.role_name, var.function_name) : null
+  # Defaulting to "*" (an invalid character for an IAM Role name) will cause an error when
+  #   attempting to plan if the role_name and function_name are not set.  This is a workaround
+  #   for #83 that will allow one to import resources without receiving an error from coalesce.
+  # @see https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/83
+  role_name = local.create_role ? coalesce(var.role_name, var.function_name, "*") : null
 }
 
 ###########


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Defaults the role_name to `*` within the coalesce to workaround #83.  By setting a dummy value as the default option, terraform can successfully import without erroring out because the variables are empty and null.  If one still forgot to set both values, an error will be thrown when attempting to create any of the IAM resources with the `*` value.

```
Error: invalid value for name (must match [\w+=,.@-])

  on .terraform/modules/application.lambda/iam.tf line 71, in resource "aws_iam_policy" "logs":
  71:   name   = "${local.role_name}-logs"

```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We still use terraform 0.12 and would like to upgrade to at least v1.29.0 at least up to v1.39.0.  See #83 for details involving the current issue.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes.  If anyone is using v1.39.0, it is locked to terraform 0.13 anyways and it seems this bug is specific to 0.12.  However, I wanted to put this out there in anticipation of potentially reverting the minimum version to 0.12.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

When using the versions of the module anywhere from `v1.29.0` to `v1.38.0`, I attempted to import resources only to result in the error specified in #83.  When changing the terraform file directly, (editing `.terraform/modules/lambda/iam.tf`), the import then works.  Commenting out the function name and role name being passed in results in the validate error above.