### PR TITLE
fix: make lambda function depend on the Cloudwatch log group

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -26,7 +26,7 @@ module "lambda_function" {
   source_path = "${path.module}/../fixtures/python3.8-app1"
 
   store_on_s3 = true
-  s3_bucket   = module.s3_bucket.this_s3_bucket_id
+  s3_bucket   = module.s3_bucket.s3_bucket_id
 
   layers = [
     module.lambda_layer_local.this_lambda_layer_arn,
@@ -183,7 +183,7 @@ module "lambda_layer_s3" {
   source_path = "${path.module}/../fixtures/python3.8-app1"
 
   store_on_s3 = true
-  s3_bucket   = module.s3_bucket.this_s3_bucket_id
+  s3_bucket   = module.s3_bucket.s3_bucket_id
 }
 
 ##############

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_lambda_function" "this" {
 
   tags = var.tags
 
-  depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package]
+  depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package, aws_cloudwatch_log_group.lambda]
 }
 
 resource "aws_lambda_layer_version" "this" {

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,10 @@ resource "aws_lambda_function" "this" {
 
   tags = var.tags
 
+  # Depending on the log group is necessary to allow Terraform to create the log group before AWS can.
+  # When a lambda function is invoked, AWS creates the log group automatically if it doesn't exist yet.
+  # Without the dependency, this can result in a race condition if the lambda function is invoked before
+  # Terraform can create the log group.
   depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package, aws_cloudwatch_log_group.lambda]
 }
 


### PR DESCRIPTION
## Description

Make the AWS Lambda function explicitly depend on the Cloudwatch log group. With this change, Terraform will create the log group before the lambda, and delete it after deleting the lambda.

This avoids a race condition where AWS creates the log group before Terraform can (see below). 

## Motivation and Context

If the lambda function writes logs when the log group doesn't exist, then AWS will create it, and Terraform will error with "log group already exists" on the following `terraform apply`.

It's possible to trigger this case by running `terraform destroy` when the lambda function is being invoked: the log group will be
deleted by Terraform and recreated by AWS before the lambda function is destroyed.

This change imposes an ordering between the lambda function and the log group creation/destruction, avoiding this race condition.

## Breaking Changes

No breaking change, no module API change.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

I ran `terraform init && terraform apply && terraform destroy` in the `complete/` example.
Additionally, I've been using this change in production for one month now (with repeated `terraform apply/terraform destroy`), and it fixes the issue described above (that we observed fairly consistently).
