### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.46.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -572,173 +572,194 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| external | >= 1 |
-| local | >= 1 |
-| null | >= 2 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 1 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| external | >= 1 |
-| local | >= 1 |
-| null | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_external"></a> [external](#provider\_external) | >= 1 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_lambda_event_source_mapping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) |
-| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) |
-| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) |
-| [aws_lambda_layer_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) |
-| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) |
-| [aws_lambda_provisioned_concurrency_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_provisioned_concurrency_config) |
-| [aws_s3_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) |
-| [external_external](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) |
-| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.additional_json](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.additional_jsons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.async](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.dead_letter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_attachment.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.additional_json](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.additional_jsons](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.async](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.dead_letter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.additional_many](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.additional_one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
+| [aws_lambda_layer_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
+| [aws_lambda_permission.current_version_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.unqualified_alias_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_provisioned_concurrency_config.current_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_provisioned_concurrency_config) | resource |
+| [aws_s3_bucket_object.lambda_package](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [local_file.archive_plan](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [null_resource.archive](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_arn.log_group_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
+| [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
+| [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy_document.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.async](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dead_letter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [external_external.archive_prepare](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allowed\_triggers | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
-| artifacts\_dir | Directory name where artifacts should be stored | `string` | `"builds"` | no |
-| attach\_async\_event\_policy | Controls whether async event policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_cloudwatch\_logs\_policy | Controls whether CloudWatch Logs policy should be added to IAM role for Lambda Function | `bool` | `true` | no |
-| attach\_dead\_letter\_policy | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_network\_policy | Controls whether VPC/network policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_policies | Controls whether list of policies should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_policy | Controls whether policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_policy\_json | Controls whether policy\_json should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_policy\_jsons | Controls whether policy\_jsons should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_policy\_statements | Controls whether policy\_statements should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| attach\_tracing\_policy | Controls whether X-Ray tracing policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
-| build\_in\_docker | Whether to build dependencies in Docker | `bool` | `false` | no |
-| cloudwatch\_logs\_kms\_key\_id | The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
-| cloudwatch\_logs\_retention\_in\_days | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `null` | no |
-| cloudwatch\_logs\_tags | A map of tags to assign to the resource. | `map(string)` | `{}` | no |
-| compatible\_runtimes | A list of Runtimes this layer is compatible with. Up to 5 runtimes can be specified. | `list(string)` | `[]` | no |
-| create | Controls whether resources should be created | `bool` | `true` | no |
-| create\_async\_event\_config | Controls whether async event configuration for Lambda Function/Alias should be created | `bool` | `false` | no |
-| create\_current\_version\_allowed\_triggers | Whether to allow triggers on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
-| create\_current\_version\_async\_event\_config | Whether to allow async event configuration on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
-| create\_function | Controls whether Lambda Function resource should be created | `bool` | `true` | no |
-| create\_layer | Controls whether Lambda Layer resource should be created | `bool` | `false` | no |
-| create\_package | Controls whether Lambda package should be created | `bool` | `true` | no |
-| create\_role | Controls whether IAM role for Lambda Function should be created | `bool` | `true` | no |
-| create\_unqualified\_alias\_allowed\_triggers | Whether to allow triggers on unqualified alias pointing to $LATEST version | `bool` | `true` | no |
-| create\_unqualified\_alias\_async\_event\_config | Whether to allow async event configuration on unqualified alias pointing to $LATEST version | `bool` | `true` | no |
-| dead\_letter\_target\_arn | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
-| description | Description of your Lambda Function (or Layer) | `string` | `""` | no |
-| destination\_on\_failure | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
-| destination\_on\_success | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
-| docker\_build\_root | Root dir where to build in Docker | `string` | `""` | no |
-| docker\_file | Path to a Dockerfile when building in Docker | `string` | `""` | no |
-| docker\_image | Docker image to use for the build | `string` | `""` | no |
-| docker\_pip\_cache | Whether to mount a shared pip cache folder into docker environment or not | `any` | `null` | no |
-| docker\_with\_ssh\_agent | Whether to pass SSH\_AUTH\_SOCK into docker environment or not | `bool` | `false` | no |
-| environment\_variables | A map that defines environment variables for the Lambda Function. | `map(string)` | `{}` | no |
-| event\_source\_mapping | Map of event source mapping | `any` | `{}` | no |
-| file\_system\_arn | The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system. | `string` | `null` | no |
-| file\_system\_local\_mount\_path | The path where the function can access the file system, starting with /mnt/. | `string` | `null` | no |
-| function\_name | A unique name for your Lambda Function | `string` | `""` | no |
-| handler | Lambda Function entrypoint in your code | `string` | `""` | no |
-| hash\_extra | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
-| image\_config\_command | The CMD for the docker image | `list(string)` | `[]` | no |
-| image\_config\_entry\_point | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |
-| image\_config\_working\_directory | The working directory for the docker image | `string` | `null` | no |
-| image\_uri | The ECR image URI containing the function's deployment package. | `string` | `null` | no |
-| kms\_key\_arn | The ARN of KMS key to use by your Lambda Function | `string` | `null` | no |
-| lambda\_at\_edge | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
-| lambda\_role | IAM role ARN attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details. | `string` | `""` | no |
-| layer\_name | Name of Lambda Layer to create | `string` | `""` | no |
-| layers | List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. | `list(string)` | `null` | no |
-| license\_info | License info for your Lambda Layer. Eg, MIT or full url of a license. | `string` | `""` | no |
-| local\_existing\_package | The absolute path to an existing zip-file to use | `string` | `null` | no |
-| maximum\_event\_age\_in\_seconds | Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600. | `number` | `null` | no |
-| maximum\_retry\_attempts | Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2. | `number` | `null` | no |
-| memory\_size | Amount of memory in MB your Lambda Function can use at runtime. Valid value between 128 MB to 10,240 MB (10 GB), in 64 MB increments. | `number` | `128` | no |
-| number\_of\_policies | Number of policies to attach to IAM role for Lambda Function | `number` | `0` | no |
-| number\_of\_policy\_jsons | Number of policies JSON to attach to IAM role for Lambda Function | `number` | `0` | no |
-| package\_type | The Lambda deployment package type. Valid options: Zip or Image | `string` | `"Zip"` | no |
-| policies | List of policy statements ARN to attach to Lambda Function role | `list(string)` | `[]` | no |
-| policy | An additional policy document ARN to attach to the Lambda Function role | `string` | `null` | no |
-| policy\_json | An additional policy document as JSON to attach to the Lambda Function role | `string` | `null` | no |
-| policy\_jsons | List of additional policy documents as JSON to attach to Lambda Function role | `list(string)` | `[]` | no |
-| policy\_statements | Map of dynamic policy statements to attach to Lambda Function role | `any` | `{}` | no |
-| provisioned\_concurrent\_executions | Amount of capacity to allocate. Set to 1 or greater to enable, or set to 0 to disable provisioned concurrency. | `number` | `-1` | no |
-| publish | Whether to publish creation/change as new Lambda Function Version. | `bool` | `false` | no |
-| reserved\_concurrent\_executions | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
-| role\_description | Description of IAM role to use for Lambda Function | `string` | `null` | no |
-| role\_force\_detach\_policies | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
-| role\_name | Name of IAM role to use for Lambda Function | `string` | `null` | no |
-| role\_path | Path of IAM role to use for Lambda Function | `string` | `null` | no |
-| role\_permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function | `string` | `null` | no |
-| role\_tags | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
-| runtime | Lambda Function runtime | `string` | `""` | no |
-| s3\_acl | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
-| s3\_bucket | S3 bucket to store artifacts | `string` | `null` | no |
-| s3\_existing\_package | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
-| s3\_object\_storage\_class | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
-| s3\_object\_tags | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |
-| s3\_server\_side\_encryption | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
-| source\_path | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
-| store\_on\_s3 | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
-| tags | A map of tags to assign to resources. | `map(string)` | `{}` | no |
-| timeout | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
-| tracing\_mode | Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active. | `string` | `null` | no |
-| trusted\_entities | Lambda Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
-| use\_existing\_cloudwatch\_log\_group | Whether to use an existing CloudWatch log group or create new | `bool` | `false` | no |
-| vpc\_security\_group\_ids | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `null` | no |
-| vpc\_subnet\_ids | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |
+| <a name="input_allowed_triggers"></a> [allowed\_triggers](#input\_allowed\_triggers) | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
+| <a name="input_artifacts_dir"></a> [artifacts\_dir](#input\_artifacts\_dir) | Directory name where artifacts should be stored | `string` | `"builds"` | no |
+| <a name="input_attach_async_event_policy"></a> [attach\_async\_event\_policy](#input\_attach\_async\_event\_policy) | Controls whether async event policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_cloudwatch_logs_policy"></a> [attach\_cloudwatch\_logs\_policy](#input\_attach\_cloudwatch\_logs\_policy) | Controls whether CloudWatch Logs policy should be added to IAM role for Lambda Function | `bool` | `true` | no |
+| <a name="input_attach_dead_letter_policy"></a> [attach\_dead\_letter\_policy](#input\_attach\_dead\_letter\_policy) | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_network_policy"></a> [attach\_network\_policy](#input\_attach\_network\_policy) | Controls whether VPC/network policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_policies"></a> [attach\_policies](#input\_attach\_policies) | Controls whether list of policies should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_policy"></a> [attach\_policy](#input\_attach\_policy) | Controls whether policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_policy_json"></a> [attach\_policy\_json](#input\_attach\_policy\_json) | Controls whether policy\_json should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_policy_jsons"></a> [attach\_policy\_jsons](#input\_attach\_policy\_jsons) | Controls whether policy\_jsons should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_policy_statements"></a> [attach\_policy\_statements](#input\_attach\_policy\_statements) | Controls whether policy\_statements should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_attach_tracing_policy"></a> [attach\_tracing\_policy](#input\_attach\_tracing\_policy) | Controls whether X-Ray tracing policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
+| <a name="input_build_in_docker"></a> [build\_in\_docker](#input\_build\_in\_docker) | Whether to build dependencies in Docker | `bool` | `false` | no |
+| <a name="input_cloudwatch_logs_kms_key_id"></a> [cloudwatch\_logs\_kms\_key\_id](#input\_cloudwatch\_logs\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
+| <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `null` | no |
+| <a name="input_cloudwatch_logs_tags"></a> [cloudwatch\_logs\_tags](#input\_cloudwatch\_logs\_tags) | A map of tags to assign to the resource. | `map(string)` | `{}` | no |
+| <a name="input_compatible_runtimes"></a> [compatible\_runtimes](#input\_compatible\_runtimes) | A list of Runtimes this layer is compatible with. Up to 5 runtimes can be specified. | `list(string)` | `[]` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls whether resources should be created | `bool` | `true` | no |
+| <a name="input_create_async_event_config"></a> [create\_async\_event\_config](#input\_create\_async\_event\_config) | Controls whether async event configuration for Lambda Function/Alias should be created | `bool` | `false` | no |
+| <a name="input_create_current_version_allowed_triggers"></a> [create\_current\_version\_allowed\_triggers](#input\_create\_current\_version\_allowed\_triggers) | Whether to allow triggers on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
+| <a name="input_create_current_version_async_event_config"></a> [create\_current\_version\_async\_event\_config](#input\_create\_current\_version\_async\_event\_config) | Whether to allow async event configuration on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
+| <a name="input_create_function"></a> [create\_function](#input\_create\_function) | Controls whether Lambda Function resource should be created | `bool` | `true` | no |
+| <a name="input_create_layer"></a> [create\_layer](#input\_create\_layer) | Controls whether Lambda Layer resource should be created | `bool` | `false` | no |
+| <a name="input_create_package"></a> [create\_package](#input\_create\_package) | Controls whether Lambda package should be created | `bool` | `true` | no |
+| <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM role for Lambda Function should be created | `bool` | `true` | no |
+| <a name="input_create_unqualified_alias_allowed_triggers"></a> [create\_unqualified\_alias\_allowed\_triggers](#input\_create\_unqualified\_alias\_allowed\_triggers) | Whether to allow triggers on unqualified alias pointing to $LATEST version | `bool` | `true` | no |
+| <a name="input_create_unqualified_alias_async_event_config"></a> [create\_unqualified\_alias\_async\_event\_config](#input\_create\_unqualified\_alias\_async\_event\_config) | Whether to allow async event configuration on unqualified alias pointing to $LATEST version | `bool` | `true` | no |
+| <a name="input_dead_letter_target_arn"></a> [dead\_letter\_target\_arn](#input\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails. | `string` | `null` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description of your Lambda Function (or Layer) | `string` | `""` | no |
+| <a name="input_destination_on_failure"></a> [destination\_on\_failure](#input\_destination\_on\_failure) | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
+| <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
+| <a name="input_docker_build_root"></a> [docker\_build\_root](#input\_docker\_build\_root) | Root dir where to build in Docker | `string` | `""` | no |
+| <a name="input_docker_file"></a> [docker\_file](#input\_docker\_file) | Path to a Dockerfile when building in Docker | `string` | `""` | no |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image to use for the build | `string` | `""` | no |
+| <a name="input_docker_pip_cache"></a> [docker\_pip\_cache](#input\_docker\_pip\_cache) | Whether to mount a shared pip cache folder into docker environment or not | `any` | `null` | no |
+| <a name="input_docker_with_ssh_agent"></a> [docker\_with\_ssh\_agent](#input\_docker\_with\_ssh\_agent) | Whether to pass SSH\_AUTH\_SOCK into docker environment or not | `bool` | `false` | no |
+| <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | A map that defines environment variables for the Lambda Function. | `map(string)` | `{}` | no |
+| <a name="input_event_source_mapping"></a> [event\_source\_mapping](#input\_event\_source\_mapping) | Map of event source mapping | `any` | `{}` | no |
+| <a name="input_file_system_arn"></a> [file\_system\_arn](#input\_file\_system\_arn) | The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system. | `string` | `null` | no |
+| <a name="input_file_system_local_mount_path"></a> [file\_system\_local\_mount\_path](#input\_file\_system\_local\_mount\_path) | The path where the function can access the file system, starting with /mnt/. | `string` | `null` | no |
+| <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for your Lambda Function | `string` | `""` | no |
+| <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
+| <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
+| <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
+| <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |
+| <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | The working directory for the docker image | `string` | `null` | no |
+| <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The ECR image URI containing the function's deployment package. | `string` | `null` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of KMS key to use by your Lambda Function | `string` | `null` | no |
+| <a name="input_lambda_at_edge"></a> [lambda\_at\_edge](#input\_lambda\_at\_edge) | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
+| <a name="input_lambda_role"></a> [lambda\_role](#input\_lambda\_role) | IAM role ARN attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See Lambda Permission Model for more details. | `string` | `""` | no |
+| <a name="input_layer_name"></a> [layer\_name](#input\_layer\_name) | Name of Lambda Layer to create | `string` | `""` | no |
+| <a name="input_layers"></a> [layers](#input\_layers) | List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. | `list(string)` | `null` | no |
+| <a name="input_license_info"></a> [license\_info](#input\_license\_info) | License info for your Lambda Layer. Eg, MIT or full url of a license. | `string` | `""` | no |
+| <a name="input_local_existing_package"></a> [local\_existing\_package](#input\_local\_existing\_package) | The absolute path to an existing zip-file to use | `string` | `null` | no |
+| <a name="input_maximum_event_age_in_seconds"></a> [maximum\_event\_age\_in\_seconds](#input\_maximum\_event\_age\_in\_seconds) | Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600. | `number` | `null` | no |
+| <a name="input_maximum_retry_attempts"></a> [maximum\_retry\_attempts](#input\_maximum\_retry\_attempts) | Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2. | `number` | `null` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MB your Lambda Function can use at runtime. Valid value between 128 MB to 10,240 MB (10 GB), in 64 MB increments. | `number` | `128` | no |
+| <a name="input_number_of_policies"></a> [number\_of\_policies](#input\_number\_of\_policies) | Number of policies to attach to IAM role for Lambda Function | `number` | `0` | no |
+| <a name="input_number_of_policy_jsons"></a> [number\_of\_policy\_jsons](#input\_number\_of\_policy\_jsons) | Number of policies JSON to attach to IAM role for Lambda Function | `number` | `0` | no |
+| <a name="input_package_type"></a> [package\_type](#input\_package\_type) | The Lambda deployment package type. Valid options: Zip or Image | `string` | `"Zip"` | no |
+| <a name="input_policies"></a> [policies](#input\_policies) | List of policy statements ARN to attach to Lambda Function role | `list(string)` | `[]` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | An additional policy document ARN to attach to the Lambda Function role | `string` | `null` | no |
+| <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | An additional policy document as JSON to attach to the Lambda Function role | `string` | `null` | no |
+| <a name="input_policy_jsons"></a> [policy\_jsons](#input\_policy\_jsons) | List of additional policy documents as JSON to attach to Lambda Function role | `list(string)` | `[]` | no |
+| <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | Map of dynamic policy statements to attach to Lambda Function role | `any` | `{}` | no |
+| <a name="input_provisioned_concurrent_executions"></a> [provisioned\_concurrent\_executions](#input\_provisioned\_concurrent\_executions) | Amount of capacity to allocate. Set to 1 or greater to enable, or set to 0 to disable provisioned concurrency. | `number` | `-1` | no |
+| <a name="input_publish"></a> [publish](#input\_publish) | Whether to publish creation/change as new Lambda Function Version. | `bool` | `false` | no |
+| <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for Lambda Function | `string` | `null` | no |
+| <a name="input_role_force_detach_policies"></a> [role\_force\_detach\_policies](#input\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Lambda Function | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role to use for Lambda Function | `string` | `null` | no |
+| <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function | `string` | `null` | no |
+| <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda Function runtime | `string` | `""` | no |
+| <a name="input_s3_acl"></a> [s3\_acl](#input\_s3\_acl) | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
+| <a name="input_s3_existing_package"></a> [s3\_existing\_package](#input\_s3\_existing\_package) | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
+| <a name="input_s3_object_storage_class"></a> [s3\_object\_storage\_class](#input\_s3\_object\_storage\_class) | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
+| <a name="input_s3_object_tags"></a> [s3\_object\_tags](#input\_s3\_object\_tags) | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |
+| <a name="input_s3_server_side_encryption"></a> [s3\_server\_side\_encryption](#input\_s3\_server\_side\_encryption) | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
+| <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
+| <a name="input_store_on_s3"></a> [store\_on\_s3](#input\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
+| <a name="input_tracing_mode"></a> [tracing\_mode](#input\_tracing\_mode) | Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active. | `string` | `null` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Lambda Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
+| <a name="input_use_existing_cloudwatch_log_group"></a> [use\_existing\_cloudwatch\_log\_group](#input\_use\_existing\_cloudwatch\_log\_group) | Whether to use an existing CloudWatch log group or create new | `bool` | `false` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `null` | no |
+| <a name="input_vpc_subnet_ids"></a> [vpc\_subnet\_ids](#input\_vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_cloudwatch\_log\_group\_name | The name of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_event\_source\_mapping\_function\_arn | The the ARN of the Lambda function the event source mapping is sending events to |
-| this\_lambda\_event\_source\_mapping\_state | The state of the event source mapping |
-| this\_lambda\_event\_source\_mapping\_state\_transition\_reason | The reason the event source mapping is in its current state |
-| this\_lambda\_event\_source\_mapping\_uuid | The UUID of the created event source mapping |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_cloudwatch_log_group_name"></a> [lambda\_cloudwatch\_log\_group\_name](#output\_lambda\_cloudwatch\_log\_group\_name) | The name of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_event_source_mapping_function_arn"></a> [this\_lambda\_event\_source\_mapping\_function\_arn](#output\_this\_lambda\_event\_source\_mapping\_function\_arn) | The the ARN of the Lambda function the event source mapping is sending events to |
+| <a name="output_this_lambda_event_source_mapping_state"></a> [this\_lambda\_event\_source\_mapping\_state](#output\_this\_lambda\_event\_source\_mapping\_state) | The state of the event source mapping |
+| <a name="output_this_lambda_event_source_mapping_state_transition_reason"></a> [this\_lambda\_event\_source\_mapping\_state\_transition\_reason](#output\_this\_lambda\_event\_source\_mapping\_state\_transition\_reason) | The reason the event source mapping is in its current state |
+| <a name="output_this_lambda_event_source_mapping_uuid"></a> [this\_lambda\_event\_source\_mapping\_uuid](#output\_this\_lambda\_event\_source\_mapping\_uuid) | The UUID of the created event source mapping |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -19,60 +19,60 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| alias_existing | ../../modules/alias |  |
-| alias_no_refresh | ../../modules/alias |  |
-| alias_refresh | ../../modules/alias |  |
-| lambda_function | ../../ |  |
+| <a name="module_alias_existing"></a> [alias\_existing](#module\_alias\_existing) | ../../modules/alias |  |
+| <a name="module_alias_no_refresh"></a> [alias\_no\_refresh](#module\_alias\_no\_refresh) | ../../modules/alias |  |
+| <a name="module_alias_refresh"></a> [alias\_refresh](#module\_alias\_refresh) | ../../modules/alias |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_alias\_arn | The ARN of the Lambda Function Alias |
-| this\_lambda\_alias\_description | Description of alias |
-| this\_lambda\_alias\_function\_version | Lambda function version which the alias uses |
-| this\_lambda\_alias\_invoke\_arn | The ARN to be used for invoking Lambda Function from API Gateway |
-| this\_lambda\_alias\_name | The name of the Lambda Function Alias |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_alias_arn"></a> [this\_lambda\_alias\_arn](#output\_this\_lambda\_alias\_arn) | The ARN of the Lambda Function Alias |
+| <a name="output_this_lambda_alias_description"></a> [this\_lambda\_alias\_description](#output\_this\_lambda\_alias\_description) | Description of alias |
+| <a name="output_this_lambda_alias_function_version"></a> [this\_lambda\_alias\_function\_version](#output\_this\_lambda\_alias\_function\_version) | Lambda function version which the alias uses |
+| <a name="output_this_lambda_alias_invoke_arn"></a> [this\_lambda\_alias\_invoke\_arn](#output\_this\_lambda\_alias\_invoke\_arn) | The ARN to be used for invoking Lambda Function from API Gateway |
+| <a name="output_this_lambda_alias_name"></a> [this\_lambda\_alias\_name](#output\_this\_lambda\_alias\_name) | The name of the Lambda Function Alias |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -19,56 +19,56 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) |
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_sns_topic.async](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sqs_queue.async](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -19,42 +19,42 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function_from_package | ../../ |  |
-| lambda_layer | ../../ |  |
-| package_dir | ../../ |  |
-| package_dir_without_pip_install | ../../ |  |
-| package_file | ../../ |  |
-| package_file_with_pip_requirements | ../../ |  |
-| package_with_commands_and_patterns | ../../ |  |
-| package_with_docker | ../../ |  |
-| package_with_patterns | ../../ |  |
-| package_with_pip_requirements_in_docker | ../../ |  |
+| <a name="module_lambda_function_from_package"></a> [lambda\_function\_from\_package](#module\_lambda\_function\_from\_package) | ../../ |  |
+| <a name="module_lambda_layer"></a> [lambda\_layer](#module\_lambda\_layer) | ../../ |  |
+| <a name="module_package_dir"></a> [package\_dir](#module\_package\_dir) | ../../ |  |
+| <a name="module_package_dir_without_pip_install"></a> [package\_dir\_without\_pip\_install](#module\_package\_dir\_without\_pip\_install) | ../../ |  |
+| <a name="module_package_file"></a> [package\_file](#module\_package\_file) | ../../ |  |
+| <a name="module_package_file_with_pip_requirements"></a> [package\_file\_with\_pip\_requirements](#module\_package\_file\_with\_pip\_requirements) | ../../ |  |
+| <a name="module_package_with_commands_and_patterns"></a> [package\_with\_commands\_and\_patterns](#module\_package\_with\_commands\_and\_patterns) | ../../ |  |
+| <a name="module_package_with_docker"></a> [package\_with\_docker](#module\_package\_with\_docker) | ../../ |  |
+| <a name="module_package_with_patterns"></a> [package\_with\_patterns](#module\_package\_with\_patterns) | ../../ |  |
+| <a name="module_package_with_pip_requirements_in_docker"></a> [package\_with\_pip\_requirements\_in\_docker](#module\_package\_with\_pip\_requirements\_in\_docker) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,62 +20,62 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.67 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.67 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.67 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| disabled_lambda | ../../ |  |
-| lambda_at_edge | ../../ |  |
-| lambda_function | ../../ |  |
-| lambda_function_existing_package_local | ../../ |  |
-| lambda_layer_local | ../../ |  |
-| lambda_layer_s3 | ../../ |  |
-| lambda_with_provisioned_concurrency | ../../ |  |
-| s3_bucket | terraform-aws-modules/s3-bucket/aws |  |
+| <a name="module_disabled_lambda"></a> [disabled\_lambda](#module\_disabled\_lambda) | ../../ |  |
+| <a name="module_lambda_at_edge"></a> [lambda\_at\_edge](#module\_lambda\_at\_edge) | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
+| <a name="module_lambda_function_existing_package_local"></a> [lambda\_function\_existing\_package\_local](#module\_lambda\_function\_existing\_package\_local) | ../../ |  |
+| <a name="module_lambda_layer_local"></a> [lambda\_layer\_local](#module\_lambda\_layer\_local) | ../../ |  |
+| <a name="module_lambda_layer_s3"></a> [lambda\_layer\_s3](#module\_lambda\_layer\_s3) | ../../ |  |
+| <a name="module_lambda_with_provisioned_concurrency"></a> [lambda\_with\_provisioned\_concurrency](#module\_lambda\_with\_provisioned\_concurrency) | ../../ |  |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_sqs_queue.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -19,59 +19,59 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.19 |
-| docker | >= 2.8.0 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 2.8.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| docker | >= 2.8.0 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.8.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function_from_container_image | ../../ |  |
+| <a name="module_lambda_function_from_container_image"></a> [lambda\_function\_from\_container\_image](#module\_lambda\_function\_from\_container\_image) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_ecr_authorization_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_authorization_token) |
-| [aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-| [docker_registry_image](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [docker_registry_image.app](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_ecr_authorization_token.token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_authorization_token) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -19,47 +19,48 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| alias_refresh | ../../modules/alias |  |
-| deploy | ../../modules/deploy |  |
-| lambda_function | ../../ |  |
+| <a name="module_alias_refresh"></a> [alias\_refresh](#module\_alias\_refresh) | ../../modules/alias |  |
+| <a name="module_deploy"></a> [deploy](#module\_deploy) | ../../modules/deploy |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_sns_topic.sns1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.sns2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| appspec | Appspec data as HCL |
-| appspec\_content | Appspec data as valid JSON |
-| appspec\_sha256 | SHA256 of Appspec JSON |
-| codedeploy\_app\_name | Name of CodeDeploy application |
-| codedeploy\_deployment\_group\_id | CodeDeploy deployment group id |
-| codedeploy\_deployment\_group\_name | CodeDeploy deployment group name |
-| codedeploy\_iam\_role\_name | Name of IAM role used by CodeDeploy |
-| deploy\_script | Path to a deployment script |
-| script | Deployment script |
+| <a name="output_appspec"></a> [appspec](#output\_appspec) | Appspec data as HCL |
+| <a name="output_appspec_content"></a> [appspec\_content](#output\_appspec\_content) | Appspec data as valid JSON |
+| <a name="output_appspec_sha256"></a> [appspec\_sha256](#output\_appspec\_sha256) | SHA256 of Appspec JSON |
+| <a name="output_codedeploy_app_name"></a> [codedeploy\_app\_name](#output\_codedeploy\_app\_name) | Name of CodeDeploy application |
+| <a name="output_codedeploy_deployment_group_id"></a> [codedeploy\_deployment\_group\_id](#output\_codedeploy\_deployment\_group\_id) | CodeDeploy deployment group id |
+| <a name="output_codedeploy_deployment_group_name"></a> [codedeploy\_deployment\_group\_name](#output\_codedeploy\_deployment\_group\_name) | CodeDeploy deployment group name |
+| <a name="output_codedeploy_iam_role_name"></a> [codedeploy\_iam\_role\_name](#output\_codedeploy\_iam\_role\_name) | Name of IAM role used by CodeDeploy |
+| <a name="output_deploy_script"></a> [deploy\_script](#output\_deploy\_script) | Path to a deployment script |
+| <a name="output_script"></a> [script](#output\_script) | Deployment script |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -20,57 +20,58 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| aws.us-east-1 | >= 3.19 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 3.19 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function | ../../ |  |
-| lambda_function_another_region | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
+| <a name="module_lambda_function_another_region"></a> [lambda\_function\_another\_region](#module\_lambda\_function\_another\_region) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_sqs_queue.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_sqs_queue.dlq_us_east_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -19,53 +19,53 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -20,56 +20,56 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.67 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.67 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.67 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudwatch_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) |
-| [aws_cloudwatch_event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.scan_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.scan_ami_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -20,58 +20,58 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function_with_efs | ../../ |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_lambda_function_with_efs"></a> [lambda\_function\_with\_efs](#module\_lambda\_function\_with\_efs) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_efs_access_point](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) |
-| [aws_efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) |
-| [aws_efs_mount_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_efs_access_point.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_access_point) | resource |
+| [aws_efs_file_system.shared](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
+| [aws_efs_mount_target.alpha](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -21,54 +21,54 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.19 |
-| random | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| lambda_function_in_vpc | ../../ |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_lambda_function_in_vpc"></a> [lambda\_function\_in\_vpc](#module\_lambda\_function\_in\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws |  |
 
 ## Resources
 
-| Name |
-|------|
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -115,60 +115,62 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_alias) |
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) |
-| [aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) |
-| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) |
+| Name | Type |
+|------|------|
+| [aws_lambda_alias.no_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
+| [aws_lambda_alias.with_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
+| [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
+| [aws_lambda_permission.qualified_alias_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.version_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_alias.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_alias) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allowed\_triggers | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
-| create | Controls whether resources should be created | `bool` | `true` | no |
-| create\_async\_event\_config | Controls whether async event configuration for Lambda Function/Alias should be created | `bool` | `false` | no |
-| create\_qualified\_alias\_allowed\_triggers | Whether to allow triggers on qualified alias | `bool` | `true` | no |
-| create\_qualified\_alias\_async\_event\_config | Whether to allow async event configuration on qualified alias | `bool` | `true` | no |
-| create\_version\_allowed\_triggers | Whether to allow triggers on version of Lambda Function used by alias (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
-| create\_version\_async\_event\_config | Whether to allow async event configuration on version of Lambda Function used by alias (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
-| description | Description of the alias. | `string` | `""` | no |
-| destination\_on\_failure | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
-| destination\_on\_success | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
-| function\_name | The function ARN of the Lambda function for which you want to create an alias. | `string` | `""` | no |
-| function\_version | Lambda function version for which you are creating the alias. Pattern: ($LATEST\|[0-9]+). | `string` | `""` | no |
-| maximum\_event\_age\_in\_seconds | Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600. | `number` | `null` | no |
-| maximum\_retry\_attempts | Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2. | `number` | `null` | no |
-| name | Name for the alias you are creating. | `string` | `""` | no |
-| refresh\_alias | Whether to refresh function version used in the alias. Useful when using this module together with external tool do deployments (eg, AWS CodeDeploy). | `bool` | `true` | no |
-| routing\_additional\_version\_weights | A map that defines the proportion of events that should be sent to different versions of a lambda function. | `map(number)` | `{}` | no |
-| use\_existing\_alias | Whether to manage existing alias instead of creating a new one. Useful when using this module together with external tool do deployments (eg, AWS CodeDeploy). | `bool` | `false` | no |
+| <a name="input_allowed_triggers"></a> [allowed\_triggers](#input\_allowed\_triggers) | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls whether resources should be created | `bool` | `true` | no |
+| <a name="input_create_async_event_config"></a> [create\_async\_event\_config](#input\_create\_async\_event\_config) | Controls whether async event configuration for Lambda Function/Alias should be created | `bool` | `false` | no |
+| <a name="input_create_qualified_alias_allowed_triggers"></a> [create\_qualified\_alias\_allowed\_triggers](#input\_create\_qualified\_alias\_allowed\_triggers) | Whether to allow triggers on qualified alias | `bool` | `true` | no |
+| <a name="input_create_qualified_alias_async_event_config"></a> [create\_qualified\_alias\_async\_event\_config](#input\_create\_qualified\_alias\_async\_event\_config) | Whether to allow async event configuration on qualified alias | `bool` | `true` | no |
+| <a name="input_create_version_allowed_triggers"></a> [create\_version\_allowed\_triggers](#input\_create\_version\_allowed\_triggers) | Whether to allow triggers on version of Lambda Function used by alias (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
+| <a name="input_create_version_async_event_config"></a> [create\_version\_async\_event\_config](#input\_create\_version\_async\_event\_config) | Whether to allow async event configuration on version of Lambda Function used by alias (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description of the alias. | `string` | `""` | no |
+| <a name="input_destination_on_failure"></a> [destination\_on\_failure](#input\_destination\_on\_failure) | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
+| <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
+| <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The function ARN of the Lambda function for which you want to create an alias. | `string` | `""` | no |
+| <a name="input_function_version"></a> [function\_version](#input\_function\_version) | Lambda function version for which you are creating the alias. Pattern: ($LATEST\|[0-9]+). | `string` | `""` | no |
+| <a name="input_maximum_event_age_in_seconds"></a> [maximum\_event\_age\_in\_seconds](#input\_maximum\_event\_age\_in\_seconds) | Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600. | `number` | `null` | no |
+| <a name="input_maximum_retry_attempts"></a> [maximum\_retry\_attempts](#input\_maximum\_retry\_attempts) | Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2. | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for the alias you are creating. | `string` | `""` | no |
+| <a name="input_refresh_alias"></a> [refresh\_alias](#input\_refresh\_alias) | Whether to refresh function version used in the alias. Useful when using this module together with external tool do deployments (eg, AWS CodeDeploy). | `bool` | `true` | no |
+| <a name="input_routing_additional_version_weights"></a> [routing\_additional\_version\_weights](#input\_routing\_additional\_version\_weights) | A map that defines the proportion of events that should be sent to different versions of a lambda function. | `map(number)` | `{}` | no |
+| <a name="input_use_existing_alias"></a> [use\_existing\_alias](#input\_use\_existing\_alias) | Whether to manage existing alias instead of creating a new one. Useful when using this module together with external tool do deployments (eg, AWS CodeDeploy). | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_lambda\_alias\_arn | The ARN of the Lambda Function Alias |
-| this\_lambda\_alias\_description | Description of alias |
-| this\_lambda\_alias\_function\_version | Lambda function version which the alias uses |
-| this\_lambda\_alias\_invoke\_arn | The ARN to be used for invoking Lambda Function from API Gateway |
-| this\_lambda\_alias\_name | The name of the Lambda Function Alias |
+| <a name="output_this_lambda_alias_arn"></a> [this\_lambda\_alias\_arn](#output\_this\_lambda\_alias\_arn) | The ARN of the Lambda Function Alias |
+| <a name="output_this_lambda_alias_description"></a> [this\_lambda\_alias\_description](#output\_this\_lambda\_alias\_description) | Description of alias |
+| <a name="output_this_lambda_alias_function_version"></a> [this\_lambda\_alias\_function\_version](#output\_this\_lambda\_alias\_function\_version) | Lambda function version which the alias uses |
+| <a name="output_this_lambda_alias_invoke_arn"></a> [this\_lambda\_alias\_invoke\_arn](#output\_this\_lambda\_alias\_invoke\_arn) | The ARN to be used for invoking Lambda Function from API Gateway |
+| <a name="output_this_lambda_alias_name"></a> [this\_lambda\_alias\_name](#output\_this\_lambda\_alias\_name) | The name of the Lambda Function Alias |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -99,88 +99,90 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.19 |
-| local | >= 1 |
-| null | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| local | >= 1 |
-| null | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_codedeploy_app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app) |
-| [aws_codedeploy_deployment_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_lambda_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_alias) |
-| [aws_lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_function) |
-| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
+| Name | Type |
+|------|------|
+| [aws_codedeploy_app.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_app) | resource |
+| [aws_codedeploy_deployment_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group) | resource |
+| [aws_iam_policy.triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [local_file.deploy_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [null_resource.deploy](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_role.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+| [aws_lambda_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_alias) | data source |
+| [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_function) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| after\_allow\_traffic\_hook\_arn | ARN of Lambda function to execute after allow traffic during deployment. This function should be named CodeDeployHook\_, to match the managed AWSCodeDeployForLambda policy, unless you're using a custom role | `string` | `""` | no |
-| alarm\_enabled | Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later. | `bool` | `false` | no |
-| alarm\_ignore\_poll\_alarm\_failure | Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. | `bool` | `false` | no |
-| alarms | A list of alarms configured for the deployment group. A maximum of 10 alarms can be added to a deployment group. | `list(string)` | `[]` | no |
-| alias\_name | Name for the alias | `string` | `""` | no |
-| app\_name | Name of AWS CodeDeploy application | `string` | `""` | no |
-| attach\_triggers\_policy | Whether to attach SNS policy to CodeDeploy role when triggers are defined | `bool` | `false` | no |
-| auto\_rollback\_enabled | Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. | `bool` | `true` | no |
-| auto\_rollback\_events | List of event types that trigger a rollback. Supported types are DEPLOYMENT\_FAILURE and DEPLOYMENT\_STOP\_ON\_ALARM. | `list(string)` | <pre>[<br>  "DEPLOYMENT_STOP_ON_ALARM"<br>]</pre> | no |
-| aws\_cli\_command | Command to run as AWS CLI. May include extra arguments like region and profile. | `string` | `"aws"` | no |
-| before\_allow\_traffic\_hook\_arn | ARN of Lambda function to execute before allow traffic during deployment. This function should be named CodeDeployHook\_, to match the managed AWSCodeDeployForLambda policy, unless you're using a custom role | `string` | `""` | no |
-| codedeploy\_principals | List of CodeDeploy service principals to allow. The list can include global or regional endpoints. | `list(string)` | <pre>[<br>  "codedeploy.amazonaws.com"<br>]</pre> | no |
-| codedeploy\_role\_name | IAM role name to create or use by CodeDeploy | `string` | `""` | no |
-| create | Controls whether resources should be created | `bool` | `true` | no |
-| create\_app | Whether to create new AWS CodeDeploy app | `bool` | `false` | no |
-| create\_codedeploy\_role | Whether to create new AWS CodeDeploy IAM role | `bool` | `true` | no |
-| create\_deployment | Run AWS CLI command to create deployment | `bool` | `false` | no |
-| create\_deployment\_group | Whether to create new AWS CodeDeploy Deployment Group | `bool` | `false` | no |
-| current\_version | Current version of Lambda function version to deploy (can't be $LATEST) | `string` | `""` | no |
-| deployment\_config\_name | Name of deployment config to use | `string` | `"CodeDeployDefault.LambdaAllAtOnce"` | no |
-| deployment\_group\_name | Name of deployment group to use | `string` | `""` | no |
-| description | Description to use for the deployment | `string` | `""` | no |
-| force\_deploy | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
-| function\_name | The name of the Lambda function to deploy | `string` | `""` | no |
-| interpreter | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br>  "/bin/bash",<br>  "-c"<br>]</pre> | no |
-| save\_deploy\_script | Save deploy script locally | `bool` | `false` | no |
-| target\_version | Target version of Lambda function version to deploy | `string` | `""` | no |
-| triggers | Map of triggers which will be notified when event happens. Valid options for event types are DeploymentStart, DeploymentSuccess, DeploymentFailure, DeploymentStop, DeploymentRollback, DeploymentReady (Applies only to replacement instances in a blue/green deployment), InstanceStart, InstanceSuccess, InstanceFailure, InstanceReady. Note that not all are applicable for Lambda deployments. | `map(any)` | `{}` | no |
-| use\_existing\_app | Whether to use existing AWS CodeDeploy app | `bool` | `false` | no |
-| use\_existing\_deployment\_group | Whether to use existing AWS CodeDeploy Deployment Group | `bool` | `false` | no |
-| wait\_deployment\_completion | Wait until deployment completes. It can take a lot of time and your terraform process may lock execution for long time. | `bool` | `false` | no |
+| <a name="input_after_allow_traffic_hook_arn"></a> [after\_allow\_traffic\_hook\_arn](#input\_after\_allow\_traffic\_hook\_arn) | ARN of Lambda function to execute after allow traffic during deployment. This function should be named CodeDeployHook\_, to match the managed AWSCodeDeployForLambda policy, unless you're using a custom role | `string` | `""` | no |
+| <a name="input_alarm_enabled"></a> [alarm\_enabled](#input\_alarm\_enabled) | Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later. | `bool` | `false` | no |
+| <a name="input_alarm_ignore_poll_alarm_failure"></a> [alarm\_ignore\_poll\_alarm\_failure](#input\_alarm\_ignore\_poll\_alarm\_failure) | Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. | `bool` | `false` | no |
+| <a name="input_alarms"></a> [alarms](#input\_alarms) | A list of alarms configured for the deployment group. A maximum of 10 alarms can be added to a deployment group. | `list(string)` | `[]` | no |
+| <a name="input_alias_name"></a> [alias\_name](#input\_alias\_name) | Name for the alias | `string` | `""` | no |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of AWS CodeDeploy application | `string` | `""` | no |
+| <a name="input_attach_triggers_policy"></a> [attach\_triggers\_policy](#input\_attach\_triggers\_policy) | Whether to attach SNS policy to CodeDeploy role when triggers are defined | `bool` | `false` | no |
+| <a name="input_auto_rollback_enabled"></a> [auto\_rollback\_enabled](#input\_auto\_rollback\_enabled) | Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. | `bool` | `true` | no |
+| <a name="input_auto_rollback_events"></a> [auto\_rollback\_events](#input\_auto\_rollback\_events) | List of event types that trigger a rollback. Supported types are DEPLOYMENT\_FAILURE and DEPLOYMENT\_STOP\_ON\_ALARM. | `list(string)` | <pre>[<br>  "DEPLOYMENT_STOP_ON_ALARM"<br>]</pre> | no |
+| <a name="input_aws_cli_command"></a> [aws\_cli\_command](#input\_aws\_cli\_command) | Command to run as AWS CLI. May include extra arguments like region and profile. | `string` | `"aws"` | no |
+| <a name="input_before_allow_traffic_hook_arn"></a> [before\_allow\_traffic\_hook\_arn](#input\_before\_allow\_traffic\_hook\_arn) | ARN of Lambda function to execute before allow traffic during deployment. This function should be named CodeDeployHook\_, to match the managed AWSCodeDeployForLambda policy, unless you're using a custom role | `string` | `""` | no |
+| <a name="input_codedeploy_principals"></a> [codedeploy\_principals](#input\_codedeploy\_principals) | List of CodeDeploy service principals to allow. The list can include global or regional endpoints. | `list(string)` | <pre>[<br>  "codedeploy.amazonaws.com"<br>]</pre> | no |
+| <a name="input_codedeploy_role_name"></a> [codedeploy\_role\_name](#input\_codedeploy\_role\_name) | IAM role name to create or use by CodeDeploy | `string` | `""` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls whether resources should be created | `bool` | `true` | no |
+| <a name="input_create_app"></a> [create\_app](#input\_create\_app) | Whether to create new AWS CodeDeploy app | `bool` | `false` | no |
+| <a name="input_create_codedeploy_role"></a> [create\_codedeploy\_role](#input\_create\_codedeploy\_role) | Whether to create new AWS CodeDeploy IAM role | `bool` | `true` | no |
+| <a name="input_create_deployment"></a> [create\_deployment](#input\_create\_deployment) | Run AWS CLI command to create deployment | `bool` | `false` | no |
+| <a name="input_create_deployment_group"></a> [create\_deployment\_group](#input\_create\_deployment\_group) | Whether to create new AWS CodeDeploy Deployment Group | `bool` | `false` | no |
+| <a name="input_current_version"></a> [current\_version](#input\_current\_version) | Current version of Lambda function version to deploy (can't be $LATEST) | `string` | `""` | no |
+| <a name="input_deployment_config_name"></a> [deployment\_config\_name](#input\_deployment\_config\_name) | Name of deployment config to use | `string` | `"CodeDeployDefault.LambdaAllAtOnce"` | no |
+| <a name="input_deployment_group_name"></a> [deployment\_group\_name](#input\_deployment\_group\_name) | Name of deployment group to use | `string` | `""` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description to use for the deployment | `string` | `""` | no |
+| <a name="input_force_deploy"></a> [force\_deploy](#input\_force\_deploy) | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
+| <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name of the Lambda function to deploy | `string` | `""` | no |
+| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br>  "/bin/bash",<br>  "-c"<br>]</pre> | no |
+| <a name="input_save_deploy_script"></a> [save\_deploy\_script](#input\_save\_deploy\_script) | Save deploy script locally | `bool` | `false` | no |
+| <a name="input_target_version"></a> [target\_version](#input\_target\_version) | Target version of Lambda function version to deploy | `string` | `""` | no |
+| <a name="input_triggers"></a> [triggers](#input\_triggers) | Map of triggers which will be notified when event happens. Valid options for event types are DeploymentStart, DeploymentSuccess, DeploymentFailure, DeploymentStop, DeploymentRollback, DeploymentReady (Applies only to replacement instances in a blue/green deployment), InstanceStart, InstanceSuccess, InstanceFailure, InstanceReady. Note that not all are applicable for Lambda deployments. | `map(any)` | `{}` | no |
+| <a name="input_use_existing_app"></a> [use\_existing\_app](#input\_use\_existing\_app) | Whether to use existing AWS CodeDeploy app | `bool` | `false` | no |
+| <a name="input_use_existing_deployment_group"></a> [use\_existing\_deployment\_group](#input\_use\_existing\_deployment\_group) | Whether to use existing AWS CodeDeploy Deployment Group | `bool` | `false` | no |
+| <a name="input_wait_deployment_completion"></a> [wait\_deployment\_completion](#input\_wait\_deployment\_completion) | Wait until deployment completes. It can take a lot of time and your terraform process may lock execution for long time. | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| appspec | Appspec data as HCL |
-| appspec\_content | Appspec data as valid JSON |
-| appspec\_sha256 | SHA256 of Appspec JSON |
-| codedeploy\_app\_name | Name of CodeDeploy application |
-| codedeploy\_deployment\_group\_id | CodeDeploy deployment group id |
-| codedeploy\_deployment\_group\_name | CodeDeploy deployment group name |
-| codedeploy\_iam\_role\_name | Name of IAM role used by CodeDeploy |
-| deploy\_script | Path to a deployment script |
-| script | Deployment script |
+| <a name="output_appspec"></a> [appspec](#output\_appspec) | Appspec data as HCL |
+| <a name="output_appspec_content"></a> [appspec\_content](#output\_appspec\_content) | Appspec data as valid JSON |
+| <a name="output_appspec_sha256"></a> [appspec\_sha256](#output\_appspec\_sha256) | SHA256 of Appspec JSON |
+| <a name="output_codedeploy_app_name"></a> [codedeploy\_app\_name](#output\_codedeploy\_app\_name) | Name of CodeDeploy application |
+| <a name="output_codedeploy_deployment_group_id"></a> [codedeploy\_deployment\_group\_id](#output\_codedeploy\_deployment\_group\_id) | CodeDeploy deployment group id |
+| <a name="output_codedeploy_deployment_group_name"></a> [codedeploy\_deployment\_group\_name](#output\_codedeploy\_deployment\_group\_name) | CodeDeploy deployment group name |
+| <a name="output_codedeploy_iam_role_name"></a> [codedeploy\_iam\_role\_name](#output\_codedeploy\_iam\_role\_name) | Name of IAM role used by CodeDeploy |
+| <a name="output_deploy_script"></a> [deploy\_script](#output\_deploy\_script) | Path to a deployment script |
+| <a name="output_script"></a> [script](#output\_script) | Deployment script |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
