### PR TITLE
fix: package.py not found with -chdir option

### DIFF
--- a/package.py
+++ b/package.py
@@ -670,6 +670,8 @@ class BuildPlanManager:
                             # If path doesn't defined for a block with
                             # commands it will be set to Terraform's
                             # current working directory
+                            # NB: cwd may vary when using Terraform 0.14+ like:
+                            # `terraform -chdir=...`
                             path = query.paths.cwd
                         if batch:
                             step('sh', path, '\n'.join(batch))

--- a/package.tf
+++ b/package.tf
@@ -8,7 +8,6 @@ data "external" "archive_prepare" {
   count = var.create && var.create_package ? 1 : 0
 
   program     = [local.python, "${path.module}/package.py", "prepare"]
-  working_dir = path.cwd
 
   query = {
     paths = jsonencode({
@@ -67,7 +66,6 @@ resource "null_resource" "archive" {
       "--timestamp", data.external.archive_prepare[0].result.timestamp
     ]
     command     = data.external.archive_prepare[0].result.build_plan_filename
-    working_dir = path.cwd
   }
 
   depends_on = [local_file.archive_plan]

--- a/package.tf
+++ b/package.tf
@@ -7,7 +7,7 @@ locals {
 data "external" "archive_prepare" {
   count = var.create && var.create_package ? 1 : 0
 
-  program     = [local.python, "${path.module}/package.py", "prepare"]
+  program = [local.python, "${path.module}/package.py", "prepare"]
 
   query = {
     paths = jsonencode({
@@ -65,7 +65,7 @@ resource "null_resource" "archive" {
       local.python, "${path.module}/package.py", "build",
       "--timestamp", data.external.archive_prepare[0].result.timestamp
     ]
-    command     = data.external.archive_prepare[0].result.build_plan_filename
+    command = data.external.archive_prepare[0].result.build_plan_filename
   }
 
   depends_on = [local_file.archive_plan]


### PR DESCRIPTION
## Description

Removed the `working_dir` option from `package.tf`.

## Motivation and Context

Fixes an issue where using the `-chdir` option breaks because it can't find the `package.py` file.

https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/135

## Breaking Changes

No

## How Has This Been Tested?

Tested by running both `terraform -chdir=tf apply` and `cd tf && terraform apply`, both passed without throwing an error.