### PR TITLE
fix: Lambda function invoke for async

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -188,6 +188,7 @@ data "aws_iam_policy_document" "async" {
       "sns:Publish",
       "sqs:SendMessage",
       "events:PutEvents",
+      "lambda:InvokeFunction",
     ]
 
     resources = compact(distinct([var.destination_on_failure, var.destination_on_success]))


### PR DESCRIPTION
The async policy is missing the action to asynchronously call other lambda functions.

## Description
Added lambda:InvokeFunction into the policy document for async integrations

![image](https://user-images.githubusercontent.com/8869007/113725420-32e0b400-96eb-11eb-8ed9-5c89cfa54bdf.png)


## Motivation and Context
When I deployed a lambda of which the `destination_on_success` is another lambda arn, my caller lambda failed to call my callee lambda due to a permission error.

## Breaking Changes
Does not break changes

## How Has This Been Tested?
After adding the above changes on my local terraform module, the lambda integration works as expected.
