### PR TITLE
fix: permission for lambda-to-lambda async calls

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12\..+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/iam.tf
+++ b/iam.tf
@@ -188,6 +188,7 @@ data "aws_iam_policy_document" "async" {
       "sns:Publish",
       "sqs:SendMessage",
       "events:PutEvents",
+      "lambda:InvokeFunction",
     ]
 
     resources = compact(distinct([var.destination_on_failure, var.destination_on_success]))


### PR DESCRIPTION
The async policy is missing the action to asynchronously call other lambda functions. Duplicate of #140, which I messed up somehow due to using github UI for the first time.

## Description
Added lambda:InvokeFunction into the policy document for async integrations.

Check https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html as it states

"This operation requires permission for the lambda:InvokeFunction action."

## Motivation and Context
When I deployed a lambda of which the destination_on_success is another lambda arn, my caller lambda failed to call my callee lambda due to a permission error.

## Breaking Changes
Does not break backwards compatibility as it is an added permission.

## How Has This Been Tested?
After adding the above changes on my local terraform module, the lambda integration works as expected, i.e. it has the permission to call another lambda asynchronously.
