### PR TITLE
feat: Extended `trusted_entities` variable to support multiple types

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
 | <a name="input_tracing_mode"></a> [tracing\_mode](#input\_tracing\_mode) | Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active. | `string` | `null` | no |
-| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Lambda Function additional trusted entities for assuming roles (trust relationship) | `list(any)` | `[]` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | List of additional trusted entities for assuming Lambda Function role (trust relationship) | `any` | `[]` | no |
 | <a name="input_use_existing_cloudwatch_log_group"></a> [use\_existing\_cloudwatch\_log\_group](#input\_use\_existing\_cloudwatch\_log\_group) | Whether to use an existing CloudWatch log group or create new | `bool` | `false` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `null` | no |
 | <a name="input_vpc_subnet_ids"></a> [vpc\_subnet\_ids](#input\_vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
 | <a name="input_tracing_mode"></a> [tracing\_mode](#input\_tracing\_mode) | Tracing mode of the Lambda Function. Valid value can be either PassThrough or Active. | `string` | `null` | no |
-| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Lambda Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Lambda Function additional trusted entities for assuming roles (trust relationship) | `list(any)` | `[]` | no |
 | <a name="input_use_existing_cloudwatch_log_group"></a> [use\_existing\_cloudwatch\_log\_group](#input\_use\_existing\_cloudwatch\_log\_group) | Whether to use an existing CloudWatch log group or create new | `bool` | `false` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `null` | no |
 | <a name="input_vpc_subnet_ids"></a> [vpc\_subnet\_ids](#input\_vpc\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -41,8 +41,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_lambda_function_existing_package_local"></a> [lambda\_function\_existing\_package\_local](#module\_lambda\_function\_existing\_package\_local) | ../../ |  |
 | <a name="module_lambda_layer_local"></a> [lambda\_layer\_local](#module\_lambda\_layer\_local) | ../../ |  |
 | <a name="module_lambda_layer_s3"></a> [lambda\_layer\_s3](#module\_lambda\_layer\_s3) | ../../ |  |
+| <a name="module_lambda_with_mixed_trusted_entities"></a> [lambda\_with\_mixed\_trusted\_entities](#module\_lambda\_with\_mixed\_trusted\_entities) | ../../ |  |
 | <a name="module_lambda_with_provisioned_concurrency"></a> [lambda\_with\_provisioned\_concurrency](#module\_lambda\_with\_provisioned\_concurrency) | ../../ |  |
-| <a name="module_lambda_with_trusted_entities"></a> [lambda\_with\_trusted\_entities](#module\_lambda\_with\_trusted\_entities) | ../../ |  |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws |  |
 
 ## Resources

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -42,6 +42,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_lambda_layer_local"></a> [lambda\_layer\_local](#module\_lambda\_layer\_local) | ../../ |  |
 | <a name="module_lambda_layer_s3"></a> [lambda\_layer\_s3](#module\_lambda\_layer\_s3) | ../../ |  |
 | <a name="module_lambda_with_provisioned_concurrency"></a> [lambda\_with\_provisioned\_concurrency](#module\_lambda\_with\_provisioned\_concurrency) | ../../ |  |
+| <a name="module_lambda_with_trusted_entities"></a> [lambda\_with\_trusted\_entities](#module\_lambda\_with\_trusted\_entities) | ../../ |  |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws |  |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -227,6 +227,33 @@ module "lambda_with_provisioned_concurrency" {
   provisioned_concurrent_executions = -1 # 2
 }
 
+###############################################
+# Lambda Function with trusted entities
+###############################################
+
+module "lambda_with_trusted_entities" {
+  source = "../../"
+
+  function_name = "${random_pet.this.id}-lambda-trusted-entities"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  source_path = "${path.module}/../fixtures/python3.8-app1"
+
+  trusted_entities = [
+    {
+      type = "AWS",
+      identifiers = [
+        "arn:aws:iam::123456789012:root",
+        "999999999999",
+        "arn:aws:sts::123456789012:assumed-role/RoleName/myaccount@myprovider.com"
+      ]
+    }
+  ]
+  # trusted_entities also accepts a list of aws services :
+  # trusted_entities = ["service-name.amazonaws.com", "ecs.amazonaws.com"]
+}
+
 ###########
 # Disabled
 ###########

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -228,30 +228,34 @@ module "lambda_with_provisioned_concurrency" {
 }
 
 ###############################################
-# Lambda Function with trusted entities
+# Lambda Function with mixed trusted entities
 ###############################################
 
-module "lambda_with_trusted_entities" {
+module "lambda_with_mixed_trusted_entities" {
   source = "../../"
 
-  function_name = "${random_pet.this.id}-lambda-trusted-entities"
+  function_name = "${random_pet.this.id}-lambda-mixed-trusted-entities"
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
   source_path = "${path.module}/../fixtures/python3.8-app1"
 
   trusted_entities = [
+    "appsync.amazonaws.com",
     {
       type = "AWS",
       identifiers = [
-        "arn:aws:iam::123456789012:root",
-        "999999999999",
-        "arn:aws:sts::123456789012:assumed-role/RoleName/myaccount@myprovider.com"
+        "arn:aws:iam::307990089504:root",
+      ]
+    },
+    {
+      type = "Service",
+      identifiers = [
+        "codedeploy.amazonaws.com",
+        "ecs.amazonaws.com"
       ]
     }
   ]
-  # trusted_entities also accepts a list of aws services :
-  # trusted_entities = ["service-name.amazonaws.com", "ecs.amazonaws.com"]
 }
 
 ###########

--- a/iam.tf
+++ b/iam.tf
@@ -12,21 +12,25 @@ locals {
   #   for #83 that will allow one to import resources without receiving an error from coalesce.
   # @see https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/83
   role_name = local.create_role ? coalesce(var.role_name, var.function_name, "*") : null
+
+  # IAM Role trusted entities is a list of any (allow strings (services) and maps (type+identifiers))
+  trusted_entities_services = distinct(compact(concat(
+    slice(["lambda.amazonaws.com", "edgelambda.amazonaws.com"], 0, var.lambda_at_edge ? 2 : 1),
+    [for service in var.trusted_entities : try(tostring(service), "")]
+  )))
+
+  trusted_entities_principals = [
+    for principal in var.trusted_entities : {
+      type        = principal.type
+      identifiers = tolist(principal.identifiers)
+    }
+    if !can(tostring(principal))
+  ]
 }
 
 ###########
 # IAM role
 ###########
-
-locals {
-  trusted_service_entities = try([for service in var.trusted_entities : tostring(service)], [])
-  trusted_object_entities = try([for principal in var.trusted_entities :
-    {
-      type        = tostring(principal.type),
-      identifiers = tolist(principal.identifiers)
-    }
-  ], [])
-}
 
 data "aws_iam_policy_document" "assume_role" {
   count = local.create_role ? 1 : 0
@@ -37,11 +41,11 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = distinct(concat(slice(["lambda.amazonaws.com", "edgelambda.amazonaws.com"], 0, var.lambda_at_edge ? 2 : 1), local.trusted_service_entities))
+      identifiers = local.trusted_entities_services
     }
 
     dynamic "principals" {
-      for_each = local.trusted_object_entities
+      for_each = local.trusted_entities_principals
       content {
         type        = principals.value.type
         identifiers = principals.value.identifiers

--- a/variables.tf
+++ b/variables.tf
@@ -436,8 +436,8 @@ variable "attach_policy_statements" {
 }
 
 variable "trusted_entities" {
-  description = "Lambda Function additional trusted entities for assuming roles (trust relationship)"
-  type        = list(any)
+  description = "List of additional trusted entities for assuming Lambda Function role (trust relationship)"
+  type        = any
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -437,7 +437,7 @@ variable "attach_policy_statements" {
 
 variable "trusted_entities" {
   description = "Lambda Function additional trusted entities for assuming roles (trust relationship)"
-  type        = list(string)
+  type        = list(any)
   default     = []
 }
 


### PR DESCRIPTION
## Description
This change allows a better customization for the `trusted entities` used in the assume role policy

For example :
```hcl
trusted_entities = [
    {
      type = "AWS",
      identifiers = ["arn:aws:sts::XXXXXXXXXXXX:assumed-role/OktaRoleForXXX/xxxx@xxxx"]
    }
]
```

## Motivation and Context
Currently, `trusted_entities` input variable only accepts a list of strings which is added to the type `Service` of the assume role Principal.

For example:
```hcl
trusted_entities = ["service.amazonaws.com"]
```
Will be interpreted as :
```
Principal = {
   ~ Service = "lambda.amazonaws.com" -> [
      + "lambda.amazonaws.com",
      + "service.amazonaws.com",
    ]
}
```

In the issue https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/138 I explain that we need a `AWS` Principal in our assume role (the goal is to execute lambda in local using its assume role).

## Breaking Changes
This first version overwrites `trusted_entities` input variable. It was previously a list of (service only) strings, and now becomes a list of objects consisting of a `type` string (like `Service` or `AWS`) and an `identifiers` array of strings (like an array of services URL as before or a list of ARNs), which will break previous usages of this variable as a list of strings.

But It could also be moved to another input variable so it doesn’t break the current `trusted_entities` input variable. The only thing that is missing is a good variable name which reflects the openness of the input variable compared to the current `trusted_entities`, which actually seems to be a `trusted_services_entities`.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] I have executed the code in our project and it results in a good terraform plan :
```
module.lambda.aws_iam_role.lambda[0] will be updated in-place
  ~ resource "aws_iam_role" "lambda" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          + AWS     = [
                              + "arn:aws:sts::XXXXXXXXXXX:assumed-role/OktaRoleForXXX/xxx@xxx",
                            ]
                            # (1 unchanged element hidden)
                        }
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```
Thank you for your help and your fantastic work on this module 👏