### PR TITLE
feat: Added `cloudwatch_logs_group_name` variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ No modules.
 | <a name="input_attach_policy_statements"></a> [attach\_policy\_statements](#input\_attach\_policy\_statements) | Controls whether policy\_statements should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | <a name="input_attach_tracing_policy"></a> [attach\_tracing\_policy](#input\_attach\_tracing\_policy) | Controls whether X-Ray tracing policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | <a name="input_build_in_docker"></a> [build\_in\_docker](#input\_build\_in\_docker) | Whether to build dependencies in Docker | `bool` | `false` | no |
+| <a name="input_cloudwatch_logs_group_name"></a> [cloudwatch\_logs\_group\_name](#input\_cloudwatch\_logs\_group\_name) | Name of custom Log Group to use. | `string` | `""` | no |
 | <a name="input_cloudwatch_logs_kms_key_id"></a> [cloudwatch\_logs\_kms\_key\_id](#input\_cloudwatch\_logs\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
 | <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `null` | no |
 | <a name="input_cloudwatch_logs_tags"></a> [cloudwatch\_logs\_tags](#input\_cloudwatch\_logs\_tags) | A map of tags to assign to the resource. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_lambda_function" "this" {
 
   tags = var.tags
 
-  depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package]
+  depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package, aws_cloudwatch_log_group.lambda]
 }
 
 resource "aws_lambda_layer_version" "this" {
@@ -125,13 +125,13 @@ resource "aws_s3_bucket_object" "lambda_package" {
 data "aws_cloudwatch_log_group" "lambda" {
   count = var.create && var.create_function && !var.create_layer && var.use_existing_cloudwatch_log_group ? 1 : 0
 
-  name = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
+  name = var.cloudwatch_logs_group_name != "" ? var.cloudwatch_logs_group_name : "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
 }
 
 resource "aws_cloudwatch_log_group" "lambda" {
   count = var.create && var.create_function && !var.create_layer && !var.use_existing_cloudwatch_log_group ? 1 : 0
 
-  name              = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
+  name              = var.cloudwatch_logs_group_name != "" ? var.cloudwatch_logs_group_name : "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
   retention_in_days = var.cloudwatch_logs_retention_in_days
   kms_key_id        = var.cloudwatch_logs_kms_key_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -301,6 +301,12 @@ variable "use_existing_cloudwatch_log_group" {
   default     = false
 }
 
+variable "cloudwatch_logs_group_name" {
+  description = "Name of custom Log Group to use."
+  type        = string
+  default     = ""
+}
+
 variable "cloudwatch_logs_retention_in_days" {
   description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
   type        = number


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This change will allow to specify custom Log Group, e.g. to group all logs for one project under similar prefix.
Added also missing dependency in Lambda resource for the Log Group, as it's necessary in many cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows to group logs for the same project.
For example Lambdas under `/my-project/lambda/My-Lambda-Function/` and API GW under `/my-project/api-gw`.

<!--- If it fixes an open issue, please link to the issue here. -->
It also fixes possible issues for creating Lambda function and creating Log Group when it's name is being updated for running integration, e.g. with API Gateway. Lambda may be created and executed before Terraform creates Log Group, so Terraform will fail with error when it tries to do so.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes, only new functionality.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
I've used as local `source` for my Lambda module.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
