### PR TITLE
feat: Added destination_config in aws_lambda_event_source_mapping

### DIFF
--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -29,12 +29,11 @@ module "lambda_function" {
     dynamodb = {
       event_source_arn  = aws_dynamodb_table.this.stream_arn
       starting_position = "LATEST"
-      # This can be created but it won't be updated/removed. To be reviewed in the future.
-      #      destination_config = {
-      #        on_failure = {
-      #          destination_arn = aws_sqs_queue.failure.arn
-      #        }
-      #      }
+           destination_config = {
+             on_failure = {
+               destination_arn = aws_sqs_queue.failure.arn
+             }
+           }
     }
     kinesis = {
       event_source_arn  = aws_kinesis_stream.this.arn

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -27,13 +27,9 @@ module "lambda_function" {
       event_source_arn = aws_sqs_queue.this.arn
     }
     dynamodb = {
-      event_source_arn  = aws_dynamodb_table.this.stream_arn
-      starting_position = "LATEST"
-           destination_config = {
-             on_failure = {
-               destination_arn = aws_sqs_queue.failure.arn
-             }
-           }
+      event_source_arn           = aws_dynamodb_table.this.stream_arn
+      starting_position          = "LATEST"
+      destination_arn_on_failure = aws_sqs_queue.failure.arn
     }
     kinesis = {
       event_source_arn  = aws_kinesis_stream.this.arn

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 locals {
-  create_role = var.create && var.create_function && ! var.create_layer && var.create_role
+  create_role = var.create && var.create_function && !var.create_layer && var.create_role
 
   # Lambda@Edge uses the Cloudwatch region closest to the location where the function is executed
   # The region part of the LogGroup ARN is then replaced with a wildcard (*) so Lambda@Edge is able to log in every region
@@ -24,7 +24,7 @@ locals {
       type        = principal.type
       identifiers = tolist(principal.identifiers)
     }
-    if ! can(tostring(principal))
+    if !can(tostring(principal))
   ]
 }
 
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "logs" {
     effect = "Allow"
 
     actions = compact([
-      ! var.use_existing_cloudwatch_log_group ? "logs:CreateLogGroup" : "",
+      !var.use_existing_cloudwatch_log_group ? "logs:CreateLogGroup" : "",
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ])

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 locals {
-  create_role = var.create && var.create_function && !var.create_layer && var.create_role
+  create_role = var.create && var.create_function && ! var.create_layer && var.create_role
 
   # Lambda@Edge uses the Cloudwatch region closest to the location where the function is executed
   # The region part of the LogGroup ARN is then replaced with a wildcard (*) so Lambda@Edge is able to log in every region
@@ -24,7 +24,7 @@ locals {
       type        = principal.type
       identifiers = tolist(principal.identifiers)
     }
-    if !can(tostring(principal))
+    if ! can(tostring(principal))
   ]
 }
 
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "logs" {
     effect = "Allow"
 
     actions = compact([
-      !var.use_existing_cloudwatch_log_group ? "logs:CreateLogGroup" : "",
+      ! var.use_existing_cloudwatch_log_group ? "logs:CreateLogGroup" : "",
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ])

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   # Use a generated filename to determine when the source code has changed.
   # filename - to get package from local
   filename    = var.local_existing_package != null ? var.local_existing_package : (var.store_on_s3 ? null : element(concat(data.external.archive_prepare.*.result.filename, [null]), 0))
-  was_missing = var.local_existing_package != null ? ! fileexists(var.local_existing_package) : element(concat(data.external.archive_prepare.*.result.was_missing, [false]), 0)
+  was_missing = var.local_existing_package != null ? !fileexists(var.local_existing_package) : element(concat(data.external.archive_prepare.*.result.was_missing, [false]), 0)
 
   # s3_* - to get package from S3
   s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
@@ -12,7 +12,7 @@ locals {
 }
 
 resource "aws_lambda_function" "this" {
-  count = var.create && var.create_function && ! var.create_layer ? 1 : 0
+  count = var.create && var.create_function && !var.create_layer ? 1 : 0
 
   function_name                  = var.function_name
   description                    = var.description
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "this" {
   package_type                   = var.package_type
 
   filename         = local.filename
-  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && ! local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key
@@ -100,7 +100,7 @@ resource "aws_lambda_layer_version" "this" {
   compatible_runtimes = length(var.compatible_runtimes) > 0 ? var.compatible_runtimes : [var.runtime]
 
   filename         = local.filename
-  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && ! local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key
@@ -127,13 +127,13 @@ resource "aws_s3_bucket_object" "lambda_package" {
 }
 
 data "aws_cloudwatch_log_group" "lambda" {
-  count = var.create && var.create_function && ! var.create_layer && var.use_existing_cloudwatch_log_group ? 1 : 0
+  count = var.create && var.create_function && !var.create_layer && var.use_existing_cloudwatch_log_group ? 1 : 0
 
   name = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
 }
 
 resource "aws_cloudwatch_log_group" "lambda" {
-  count = var.create && var.create_function && ! var.create_layer && ! var.use_existing_cloudwatch_log_group ? 1 : 0
+  count = var.create && var.create_function && !var.create_layer && !var.use_existing_cloudwatch_log_group ? 1 : 0
 
   name              = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
   retention_in_days = var.cloudwatch_logs_retention_in_days
@@ -143,7 +143,7 @@ resource "aws_cloudwatch_log_group" "lambda" {
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "current_version" {
-  count = var.create && var.create_function && ! var.create_layer && var.provisioned_concurrent_executions > -1 ? 1 : 0
+  count = var.create && var.create_function && !var.create_layer && var.provisioned_concurrent_executions > -1 ? 1 : 0
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
@@ -156,7 +156,7 @@ locals {
 }
 
 resource "aws_lambda_function_event_invoke_config" "this" {
-  for_each = var.create && var.create_function && ! var.create_layer && var.create_async_event_config ? local.qualifiers : {}
+  for_each = var.create && var.create_function && !var.create_layer && var.create_async_event_config ? local.qualifiers : {}
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = each.key == "current_version" ? aws_lambda_function.this[0].version : null
@@ -185,7 +185,7 @@ resource "aws_lambda_function_event_invoke_config" "this" {
 }
 
 resource "aws_lambda_permission" "current_version_triggers" {
-  for_each = var.create && var.create_function && ! var.create_layer && var.create_current_version_allowed_triggers ? var.allowed_triggers : {}
+  for_each = var.create && var.create_function && !var.create_layer && var.create_current_version_allowed_triggers ? var.allowed_triggers : {}
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
@@ -200,7 +200,7 @@ resource "aws_lambda_permission" "current_version_triggers" {
 
 # Error: Error adding new Lambda Permission for lambda: InvalidParameterValueException: We currently do not support adding policies for $LATEST.
 resource "aws_lambda_permission" "unqualified_alias_triggers" {
-  for_each = var.create && var.create_function && ! var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.allowed_triggers : {}
+  for_each = var.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.allowed_triggers : {}
 
   function_name = aws_lambda_function.this[0].function_name
 
@@ -213,7 +213,7 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 }
 
 resource "aws_lambda_event_source_mapping" "this" {
-  for_each = var.create && var.create_function && ! var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.event_source_mapping : tomap({})
+  for_each = var.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers ? tomap(var.event_source_mapping) : tomap({})
 
   function_name = aws_lambda_function.this[0].arn
 
@@ -230,11 +230,10 @@ resource "aws_lambda_event_source_mapping" "this" {
   bisect_batch_on_function_error     = lookup(each.value, "bisect_batch_on_function_error", null)
 
   dynamic "destination_config" {
-    for_each = lookup(each.value, "destination_config", {})
-
+    for_each = lookup(each.value, "destination_arn_on_failure", null) != null ? [true] : []
     content {
       on_failure {
-        destination_arn = lookup(destination_config.value, "destination_arn")
+        destination_arn = each.value["destination_arn_on_failure"]
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   # Use a generated filename to determine when the source code has changed.
   # filename - to get package from local
   filename    = var.local_existing_package != null ? var.local_existing_package : (var.store_on_s3 ? null : element(concat(data.external.archive_prepare.*.result.filename, [null]), 0))
-  was_missing = var.local_existing_package != null ? !fileexists(var.local_existing_package) : element(concat(data.external.archive_prepare.*.result.was_missing, [false]), 0)
+  was_missing = var.local_existing_package != null ? ! fileexists(var.local_existing_package) : element(concat(data.external.archive_prepare.*.result.was_missing, [false]), 0)
 
   # s3_* - to get package from S3
   s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
@@ -12,7 +12,7 @@ locals {
 }
 
 resource "aws_lambda_function" "this" {
-  count = var.create && var.create_function && !var.create_layer ? 1 : 0
+  count = var.create && var.create_function && ! var.create_layer ? 1 : 0
 
   function_name                  = var.function_name
   description                    = var.description
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "this" {
   package_type                   = var.package_type
 
   filename         = local.filename
-  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && ! local.was_missing ? filebase64sha256(local.filename) : null
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key
@@ -100,7 +100,7 @@ resource "aws_lambda_layer_version" "this" {
   compatible_runtimes = length(var.compatible_runtimes) > 0 ? var.compatible_runtimes : [var.runtime]
 
   filename         = local.filename
-  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && ! local.was_missing ? filebase64sha256(local.filename) : null
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key
@@ -127,13 +127,13 @@ resource "aws_s3_bucket_object" "lambda_package" {
 }
 
 data "aws_cloudwatch_log_group" "lambda" {
-  count = var.create && var.create_function && !var.create_layer && var.use_existing_cloudwatch_log_group ? 1 : 0
+  count = var.create && var.create_function && ! var.create_layer && var.use_existing_cloudwatch_log_group ? 1 : 0
 
   name = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
 }
 
 resource "aws_cloudwatch_log_group" "lambda" {
-  count = var.create && var.create_function && !var.create_layer && !var.use_existing_cloudwatch_log_group ? 1 : 0
+  count = var.create && var.create_function && ! var.create_layer && ! var.use_existing_cloudwatch_log_group ? 1 : 0
 
   name              = "/aws/lambda/${var.lambda_at_edge ? "us-east-1." : ""}${var.function_name}"
   retention_in_days = var.cloudwatch_logs_retention_in_days
@@ -143,7 +143,7 @@ resource "aws_cloudwatch_log_group" "lambda" {
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "current_version" {
-  count = var.create && var.create_function && !var.create_layer && var.provisioned_concurrent_executions > -1 ? 1 : 0
+  count = var.create && var.create_function && ! var.create_layer && var.provisioned_concurrent_executions > -1 ? 1 : 0
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
@@ -156,7 +156,7 @@ locals {
 }
 
 resource "aws_lambda_function_event_invoke_config" "this" {
-  for_each = var.create && var.create_function && !var.create_layer && var.create_async_event_config ? local.qualifiers : {}
+  for_each = var.create && var.create_function && ! var.create_layer && var.create_async_event_config ? local.qualifiers : {}
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = each.key == "current_version" ? aws_lambda_function.this[0].version : null
@@ -185,7 +185,7 @@ resource "aws_lambda_function_event_invoke_config" "this" {
 }
 
 resource "aws_lambda_permission" "current_version_triggers" {
-  for_each = var.create && var.create_function && !var.create_layer && var.create_current_version_allowed_triggers ? var.allowed_triggers : {}
+  for_each = var.create && var.create_function && ! var.create_layer && var.create_current_version_allowed_triggers ? var.allowed_triggers : {}
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
@@ -200,7 +200,7 @@ resource "aws_lambda_permission" "current_version_triggers" {
 
 # Error: Error adding new Lambda Permission for lambda: InvalidParameterValueException: We currently do not support adding policies for $LATEST.
 resource "aws_lambda_permission" "unqualified_alias_triggers" {
-  for_each = var.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.allowed_triggers : {}
+  for_each = var.create && var.create_function && ! var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.allowed_triggers : {}
 
   function_name = aws_lambda_function.this[0].function_name
 
@@ -213,7 +213,7 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 }
 
 resource "aws_lambda_event_source_mapping" "this" {
-  for_each = var.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.event_source_mapping : tomap({})
+  for_each = var.create && var.create_function && ! var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.event_source_mapping : tomap({})
 
   function_name = aws_lambda_function.this[0].arn
 
@@ -229,15 +229,13 @@ resource "aws_lambda_event_source_mapping" "this" {
   maximum_record_age_in_seconds      = lookup(each.value, "maximum_record_age_in_seconds", null)
   bisect_batch_on_function_error     = lookup(each.value, "bisect_batch_on_function_error", null)
 
-  /* @todo: fix this
   dynamic "destination_config" {
     for_each = lookup(each.value, "destination_config", {})
 
     content {
       on_failure {
-        destination_arn = lookup(destination_config.value, "on_failure") #"destination_arn"]
+        destination_arn = lookup(destination_config.value, "destination_arn")
       }
     }
   }
-  */
 }


### PR DESCRIPTION
## Description
Uncommenting `destination_config` block within event_source_mapping. Git pre-commit hook performed a `terraform fmt` resulting in additional formatting changes to unrelated code.

## How Has This Been Tested?

I'm really not familiar with this module, but I tested it locally by specifying an `event_source_mapping` config similar to what is in `examples/event-source-mapping`. A `plan` and `apply` worked just fine and i could see that the "On-Failure" destination config was now configured under a dynamoDB trigger for my lambda function. I re-ran a `plan` again afterwards just to validate that no other spurious side-effects/changes were detected.