### PR TITLE
docs: Updated README with S3 bucket id handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ No modules.
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda Function runtime | `string` | `""` | no |
 | <a name="input_s3_acl"></a> [s3\_acl](#input\_s3\_acl) | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
-| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket ID to store artifacts | `string` | `null` | no |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
 | <a name="input_s3_existing_package"></a> [s3\_existing\_package](#input\_s3\_existing\_package) | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | <a name="input_s3_object_storage_class"></a> [s3\_object\_storage\_class](#input\_s3\_object\_storage\_class) | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
 | <a name="input_s3_object_tags"></a> [s3\_object\_tags](#input\_s3\_object\_tags) | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "lambda_function" {
   source_path = "../src/lambda-function1"
 
   store_on_s3 = true
-  s3_bucket   = "my-bucket-with-lambda-builds"
+  s3_bucket   = "my-bucket-id-with-lambda-builds"
 
   layers = [
     module.lambda_layer_s3.lambda_layer_arn,
@@ -86,7 +86,7 @@ module "lambda_layer_s3" {
   source_path = "../src/lambda-layer"
 
   store_on_s3 = true
-  s3_bucket   = "my-bucket-with-lambda-builds"
+  s3_bucket   = "my-bucket-id-with-lambda-builds"
 }
 ```
 
@@ -115,8 +115,13 @@ locals {
   my_function_source = "../path/to/package.zip"
 }
 
+resource "aws_s3_bucket" "builds" {
+  bucket = "my-builds"
+  acl    = "private"
+}
+
 resource "aws_s3_bucket_object" "my_function" {
-  bucket = "my-bucket-with-lambda-builds"
+  bucket = aws_s3_bucket.builds.id
   key    = "${filemd5(local.my_function_source)}.zip"
   source = local.my_function_source
 }
@@ -131,7 +136,7 @@ module "lambda_function_existing_package_s3" {
 
   create_package      = false
   s3_existing_package = {
-    bucket = "my-bucket-with-lambda-builds"
+    bucket = aws_s3_bucket.builds.id
     key    = aws_s3_bucket_object.my_function.id
   }
 }
@@ -180,7 +185,7 @@ module "lambda_layer_s3" {
   source_path = "../fixtures/python3.8-app1"
 
   store_on_s3 = true
-  s3_bucket   = "my-bucket-with-lambda-builds"
+  s3_bucket   = "my-bucket-id-with-lambda-builds"
 }
 ```
 
@@ -693,7 +698,7 @@ No modules.
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda Function runtime | `string` | `""` | no |
 | <a name="input_s3_acl"></a> [s3\_acl](#input\_s3\_acl) | The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, and bucket-owner-full-control. Defaults to private. | `string` | `"private"` | no |
-| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket ID to store artifacts | `string` | `null` | no |
 | <a name="input_s3_existing_package"></a> [s3\_existing\_package](#input\_s3\_existing\_package) | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | <a name="input_s3_object_storage_class"></a> [s3\_object\_storage\_class](#input\_s3\_object\_storage\_class) | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
 | <a name="input_s3_object_tags"></a> [s3\_object\_tags](#input\_s3\_object\_tags) | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -518,7 +518,7 @@ variable "s3_object_storage_class" {
 }
 
 variable "s3_bucket" {
-  description = "S3 bucket id to store artifacts"
+  description = "S3 bucket to store artifacts"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -518,7 +518,7 @@ variable "s3_object_storage_class" {
 }
 
 variable "s3_bucket" {
-  description = "S3 bucket to store artifacts"
+  description = "S3 bucket id to store artifacts"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding precisions regarding the S3 bucket handling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I faced validation issues because i was using the `arn` instead of the `id` of the bucket. As i saw similar people having this issue on internet, i thought it would be better to clarify this in the documentation.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None
