### PR TITLE
fix: Fix perpetual diff after upgrading to TF 0.13

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -3,8 +3,8 @@ locals {
 
   # Lambda@Edge uses the Cloudwatch region closest to the location where the function is executed
   # The region part of the LogGroup ARN is then replaced with a wildcard (*) so Lambda@Edge is able to log in every region
-  log_group_arn_regional = element(concat(data.aws_cloudwatch_log_group.lambda.*.arn, aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
-  log_group_name         = element(concat(data.aws_cloudwatch_log_group.lambda.*.name, aws_cloudwatch_log_group.lambda.*.name, [""]), 0)
+  log_group_arn_regional = var.use_existing_cloudwatch_log_group ? element(concat(data.aws_cloudwatch_log_group.lambda.*.arn, [""]), 0) : element(concat(aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
+  log_group_name         = var.use_existing_cloudwatch_log_group ? element(concat(data.aws_cloudwatch_log_group.lambda.*.name, [""]), 0) : element(concat(aws_cloudwatch_log_group.lambda.*.arn, [""]), 0)
   log_group_arn          = local.create_role && var.lambda_at_edge ? format("arn:%s:%s:%s:%s:%s", data.aws_arn.log_group_arn[0].partition, data.aws_arn.log_group_arn[0].service, "*", data.aws_arn.log_group_arn[0].account, data.aws_arn.log_group_arn[0].resource) : local.log_group_arn_regional
 
   # Defaulting to "*" (an invalid character for an IAM Role name) will cause an error when


### PR DESCRIPTION
## Description
This quick and dirty fix is to resolve the issue with perpetual differences starting with Terraform 0.13.

## Motivation and Context
After upgrading to Terraform 0.13, the module gives me the following on each apply:

```
Terraform will perform the following actions:

  # module.REDACTED.data.aws_iam_policy_document.logs[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "logs"  {
      + id      = "1935840989"
      + json    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "logs:PutLogEvents",
                          + "logs:CreateLogStream",
                          + "logs:CreateLogGroup",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:logs:eu-west-1:REDACTED:log-group:/aws/lambda/REDACTED:*:*",
                          + "arn:aws:logs:eu-west-1:REDACTED:log-group:/aws/lambda/REDACTED:*",
                        ]
                      + Sid      = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + version = "2012-10-17"

      + statement {
          + actions       = [
              + "logs:CreateLogGroup",
              + "logs:CreateLogStream",
              + "logs:PutLogEvents",
            ]
          + effect        = "Allow"
          + not_actions   = []
          + not_resources = []
          + resources     = [
              + "arn:aws:logs:eu-west-1:REDACTED:log-group:/aws/lambda/REDACTED:*",
              + "arn:aws:logs:eu-west-1:REDACTED:log-group:/aws/lambda/REDACTED:*:*",
            ]
        }
    }

[...]
more similar data resources cut
[...]

Plan: 0 to add, 0 to change, 0 to destroy.
```

I don't really use `use_existing_cloudwatch_log_group` so the provided fix let me separate the data resource `aws_cloudwatch_log_group.lambda` so it's not involved in the new [data resource dependencies](https://www.terraform.io/docs/language/data-sources/index.html#data-resource-dependencies) any more.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have tested and validated these changes with my projects only but the change is trivial.
