### PR TITLE
feat: Add topics parameter support for lambda event source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -228,6 +228,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   maximum_retry_attempts             = lookup(each.value, "maximum_retry_attempts", null)
   maximum_record_age_in_seconds      = lookup(each.value, "maximum_record_age_in_seconds", null)
   bisect_batch_on_function_error     = lookup(each.value, "bisect_batch_on_function_error", null)
+  topics                             = lookup(each.value, "topics", null)
 
   dynamic "destination_config" {
     for_each = lookup(each.value, "destination_arn_on_failure", null) != null ? [true] : []


### PR DESCRIPTION
## Description
Add topics parameter for lambda event source

## Motivation and Context
Add support to set topics for lambda event source. This is optional parameter for MSK according to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping

## Breaking Changes
No

## How Has This Been Tested?
Tested in my project. `topics` parameter can be attached for MSK event source mapping.
