### PR TITLE
fix: Strip leading `./` in S3 key if `artifacts_dir` is set to something like `${path.root}/mypath/`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 
   # s3_* - to get package from S3
   s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
-  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? element(concat(data.external.archive_prepare.*.result.filename, [null]), 0) : null)
+  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? format("%s/%s", dirname(element(concat(data.external.archive_prepare.*.result.filename, [null]), 0)), basename(element(concat(data.external.archive_prepare.*.result.filename, [null]), 0))) : null)
   s3_object_version = var.s3_existing_package != null ? lookup(var.s3_existing_package, "version_id", null) : (var.store_on_s3 ? element(concat(aws_s3_bucket_object.lambda_package.*.version_id, [null]), 0) : null)
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This change strips the leading `./` in S3 key if `artifacts_dir` is set to something like `${path.root}/mypath/`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this change, this configuration:

```
module "lambda-my-layer" {
  source  = "terraform-aws-modules/lambda/aws"
  version = "2.4.0"

  create_layer = true
  layer_name   = "my-layer"

  runtime         = "python3.8"
  build_in_docker = true

  source_path = [{
    path             = "${path.module}/lambda/my-layer/",
    pip_requirements = true,
    prefix_in_zip    = "python",
  }]

  artifacts_dir = "${path.root}/.terraform/lambda-builds/"

  store_on_s3             = true
  s3_bucket               = aws_s3_bucket.mybuckt.bucket
  s3_object_storage_class = "STANDARD"
}
```

gives the following plan excerpt:

```
  # module.lambda-my-layer.aws_lambda_layer_version.this[0] will be created
  + resource "aws_lambda_layer_version" "this" {
      + arn                         = (known after apply)
      + compatible_runtimes         = [
          + "python3.8",
        ]
      + created_date                = (known after apply)
      + id                          = (known after apply)
      + layer_arn                   = (known after apply)
      + layer_name                  = "my-layer"
      + s3_bucket                   = "s3-my-lambdas-eu-west-3-0123456789012"
      + s3_key                      = "./.terraform/lambda-builds/41c9284df0f8fadfa3437b7a70066400d35ca912bfb089b7d3e01b59870dd077.zip"
      + s3_object_version           = (known after apply)
      + signing_job_arn             = (known after apply)
      + signing_profile_version_arn = (known after apply)
      + source_code_hash            = (known after apply)
      + source_code_size            = (known after apply)
      + version                     = (known after apply)
    }
```

Which fails at apply:

```
│ Error: Error creating lambda layer: InvalidParameterValueException: Error occurred while GetObjectVersion. S3 Error Code: NoSuchVersion. S3 Error Message: The specified version does not exist.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "18230ee0-2112-45d9-850f-0123456789012"
│   },
│   Message_: "Error occurred while GetObjectVersion. S3 Error Code: NoSuchVersion. S3 Error Message: The specified version does not exist.",
│   Type: "User"
│ }
│
│   with module.lambda-cleanup-layer.aws_lambda_layer_version.this[0],
│   on .terraform/modules/lambda-cleanup-layer/main.tf line 93, in resource "aws_lambda_layer_version" "this":
│   93: resource "aws_lambda_layer_version" "this" {
```

With this change, this part of the plan:

```
  # module.lambda-my-layer.aws_lambda_layer_version.this[0] will be created
  + resource "aws_lambda_layer_version" "this" {
      + arn                         = (known after apply)
      + compatible_runtimes         = [
          + "python3.8",
        ]
      + created_date                = (known after apply)
      + id                          = (known after apply)
      + layer_arn                   = (known after apply)
      + layer_name                  = "my-layer"
      + s3_bucket                   = "s3-my-lambdas-eu-west-3-0123456789012"
      + s3_key                      = ".terraform/lambda-builds/41c9284df0f8fadfa3437b7a70066400d35ca912bfb089b7d3e01b59870dd077.zip"
      + s3_object_version           = (known after apply)
      + signing_job_arn             = (known after apply)
      + signing_profile_version_arn = (known after apply)
      + source_code_hash            = (known after apply)
      + source_code_size            = (known after apply)
      + version                     = (known after apply)
    }
```

applies successfully.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This should not be a breaking change as keys with a leading `./` are not accepted by S3.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with `examples/complete` with `build_in_docker = true` added as I only have `python3.9` locally: [terraform-aws-lambda-168.log](https://github.com/terraform-aws-modules/terraform-aws-lambda/files/6749364/terraform-aws-lambda-168.log)


I have also tested this change with my own terraform configurations.