### PR TITLE
fix: Remove `random` provider because it is not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,6 @@ terraform {
     aws      = ">= 3.35"
     external = ">= 1"
     local    = ">= 1"
-    random   = ">= 2"
     null     = ">= 2"
   }
 }


### PR DESCRIPTION
## Description
Remove unnecessary provider requirement

## Motivation and Context
Introduces unneeded provider requirement on downstream users of this module.
Fix #167

## Breaking Changes
Should not break anything, as random provider was unreferenced in main module.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
Did a successful `terraform plan` in examples/simple, and encountered no problems.
Code inspection of other examples showed that they all declare random as a required provider if they use it.

