### PR TITLE
feat: Add unique_id output of the lambda role

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.13.0/terraform-docs-v0.13.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.13.0/terraform-docs-v0.13.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ No modules.
 | <a name="output_lambda_layer_version"></a> [lambda\_layer\_version](#output\_lambda\_layer\_version) | The Lambda Layer version |
 | <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
 | <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_unique_id"></a> [lambda\_role\_unique\_id](#output\_lambda\_role\_unique\_id) | The unique id of the IAM role created for the Lambda Function |
 | <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
 | <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -101,6 +101,11 @@ output "lambda_role_name" {
   description = "The name of the IAM role created for the Lambda Function"
   value       = element(concat(aws_iam_role.lambda.*.name, [""]), 0)
 }
+  
+output "lambda_role_unique_id" {
+  description = "The name of the IAM role created for the Lambda Function"
+  value       = element(concat(aws_iam_role.lambda.*.unique_id, [""]), 0)
+}
 
 # CloudWatch Log Group
 output "lambda_cloudwatch_log_group_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -101,7 +101,7 @@ output "lambda_role_name" {
   description = "The name of the IAM role created for the Lambda Function"
   value       = element(concat(aws_iam_role.lambda.*.name, [""]), 0)
 }
-  
+
 output "lambda_role_unique_id" {
   description = "The unique id of the IAM role created for the Lambda Function"
   value       = element(concat(aws_iam_role.lambda.*.unique_id, [""]), 0)

--- a/outputs.tf
+++ b/outputs.tf
@@ -103,7 +103,7 @@ output "lambda_role_name" {
 }
   
 output "lambda_role_unique_id" {
-  description = "The name of the IAM role created for the Lambda Function"
+  description = "The unique id of the IAM role created for the Lambda Function"
   value       = element(concat(aws_iam_role.lambda.*.unique_id, [""]), 0)
 }
 


### PR DESCRIPTION
## Description
Added unique_id output of the created lambda role.

## Motivation and Context
We have s3 bucket policies that use the unique role id to restrict access to specific roles. This make sure I can create the lambda role with the module instead of creating the role separately or using a data resource to get the required variable.

## Breaking Changes
Doesn't break anything as far as I am aware.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
Applied this using terraform 13.4 and 1.0 and used the output of this feature 