### PR TITLE
feat: Add support for separate deployments of infra and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+- feat: Add `ignore_changes_package` variable to allow the lambda function resource to be managed by terraform but have the function code managed externally
 
 <a name="v2.7.0"></a>
 ## [v2.7.0] - 2021-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- feat: Add `ignore_changes_package` variable to allow the lambda function resource to be managed by terraform but have the function code managed externally
+- feat: Add `ignore_source_code_hash` variable to allow the lambda function resource to be managed by terraform but have the function code managed externally
 
 <a name="v2.7.0"></a>
 ## [v2.7.0] - 2021-07-08

--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ module "lambda_function_existing_package_local" {
 }
 ```
 
+### Lambda Function where package deployments are maintained separately to infrastructure
+
+If using this method you need to be aware of the following:
+
+1. A 'dummy' package will need to be included with your terraform code/module. This is deployed to the function when the lambda component is initialised.
+1. You will need to redeploy the real function code after the terraform apply every time the lambda function resource is recreated / force replaced; the 'dummy' package is deployed every time the lambda resource is created.
+
+```hcl
+module "lambda_function_externally_managed_package" {
+  source = "terraform-aws-modules/lambda/aws"
+
+  function_name = "my-lambda-externally-managed-package"
+  description   = "My lambda function code is deployed separately"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  create_package         = false
+  local_existing_package = "../dummy_package.zip"
+  ignore_changes_package = true
+}
+```
+
 ### Lambda Function with existing package (prebuilt) stored in S3 bucket
 
 Note that this module does not copy prebuilt packages into S3 bucket. This module can only store packages it builds locally and in S3 bucket.
@@ -664,6 +686,7 @@ No modules.
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for your Lambda Function | `string` | `""` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
+| <a name="input_ignore_changes_package"></a> [ignore\_changes\_package](#input\_ignore\_changes\_package) | Set to true to ignore changes to the function's source code package/hash. Useful when infrastructure and code deployments are managed by separate pipelines | `bool` | `false` | no |
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | The working directory for the docker image | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ No modules.
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for your Lambda Function | `string` | `""` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
-| <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Set to true to ignore changes to the function's source code hash. Useful when infrastructure and code deployments are managed by separate pipelines | `bool` | `false` | no |
+| <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | The working directory for the docker image | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ module "lambda_function_externally_managed_package" {
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
-  create_package         = false
-  local_existing_package = "../dummy_package.zip"
-  ignore_changes_package = true
+  create_package          = false
+  local_existing_package  = "./lambda_functions/dummy_lambda.zip"
+  ignore_source_code_hash = true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ No modules.
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for your Lambda Function | `string` | `""` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
-| <a name="input_ignore_changes_package"></a> [ignore\_changes\_package](#input\_ignore\_changes\_package) | Set to true to ignore changes to the function's source code package/hash. Useful when infrastructure and code deployments are managed by separate pipelines | `bool` | `false` | no |
+| <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Set to true to ignore changes to the function's source code hash. Useful when infrastructure and code deployments are managed by separate pipelines | `bool` | `false` | no |
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | The working directory for the docker image | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -106,12 +106,15 @@ module "lambda_function_existing_package_local" {
 }
 ```
 
-### Lambda Function where package deployments are maintained separately to infrastructure
+### Lambda Function or Lambda Layer with the deployable artifact maintained separately from the infrastructure
 
-If using this method you need to be aware of the following:
+If you want to manage function code and infrastructure resources (such as IAM permissions, policies, events, etc) in separate flows (e.g., different repositories, teams, CI/CD pipelines).
 
-1. A 'dummy' package will need to be included with your terraform code/module. This is deployed to the function when the lambda component is initialised.
-1. You will need to redeploy the real function code after the terraform apply every time the lambda function resource is recreated / force replaced; the 'dummy' package is deployed every time the lambda resource is created.
+Disable source code tracking to turn off deployments (and rollbacks) using the module by setting `ignore_source_code_hash = true` and deploy a _dummy function_.
+
+When the infrastructure and the dummy function is deployed, you can use external tool to update the source code of the function (eg, using [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-code.html)) and keep using this module via Terraform to manage the infrastructure.
+
+Be aware that changes in `local_existing_package` value may trigger deployment via Terraform.
 
 ```hcl
 module "lambda_function_externally_managed_package" {
@@ -122,8 +125,9 @@ module "lambda_function_externally_managed_package" {
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
-  create_package          = false
-  local_existing_package  = "./lambda_functions/dummy_lambda.zip"
+  create_package         = false
+  local_existing_package = "./lambda_functions/code.zip"
+
   ignore_source_code_hash = true
 }
 ```

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,8 +40,10 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ |  |
 | <a name="module_lambda_function_existing_package_local"></a> [lambda\_function\_existing\_package\_local](#module\_lambda\_function\_existing\_package\_local) | ../../ |  |
 | <a name="module_lambda_function_for_each"></a> [lambda\_function\_for\_each](#module\_lambda\_function\_for\_each) | ../../ |  |
+| <a name="module_lambda_function_with_package_deploying_externally"></a> [lambda\_function\_with\_package\_deploying\_externally](#module\_lambda\_function\_with\_package\_deploying\_externally) | ../../ |  |
 | <a name="module_lambda_layer_local"></a> [lambda\_layer\_local](#module\_lambda\_layer\_local) | ../../ |  |
 | <a name="module_lambda_layer_s3"></a> [lambda\_layer\_s3](#module\_lambda\_layer\_s3) | ../../ |  |
+| <a name="module_lambda_layer_with_package_deploying_externally"></a> [lambda\_layer\_with\_package\_deploying\_externally](#module\_lambda\_layer\_with\_package\_deploying\_externally) | ../../ |  |
 | <a name="module_lambda_with_mixed_trusted_entities"></a> [lambda\_with\_mixed\_trusted\_entities](#module\_lambda\_with\_mixed\_trusted\_entities) | ../../ |  |
 | <a name="module_lambda_with_provisioned_concurrency"></a> [lambda\_with\_provisioned\_concurrency](#module\_lambda\_with\_provisioned\_concurrency) | ../../ |  |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws |  |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -167,6 +167,26 @@ module "lambda_layer_local" {
   source_path = "${path.module}/../fixtures/python3.8-app1"
 }
 
+####################################################
+# Lambda Layer with package deploying externally
+# (e.g., using separate CI/CD pipeline)
+####################################################
+
+module "lambda_layer_with_package_deploying_externally" {
+  source = "../../"
+
+  create_layer = true
+
+  layer_name          = "${random_pet.this.id}-layer-local"
+  description         = "My amazing lambda layer (deployed from local)"
+  compatible_runtimes = ["python3.8"]
+
+  create_package         = false
+  local_existing_package = "../fixtures/python3.8-zip/existing_package.zip"
+
+  ignore_source_code_hash = true
+}
+
 ###############################
 # Lambda Layer (storing on S3)
 ###############################
@@ -275,6 +295,24 @@ module "lambda_function_for_each" {
 
   create_package         = false
   local_existing_package = "${path.module}/../fixtures/python3.8-zip/existing_package.zip"
+}
+
+####################################################
+# Lambda Function with package deploying externally
+# (e.g., using separate CI/CD pipeline)
+####################################################
+
+module "lambda_function_with_package_deploying_externally" {
+  source = "../../"
+
+  function_name = "${random_pet.this.id}-lambda-with-package-deploying-externally"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  create_package         = false
+  local_existing_package = "../fixtures/python3.8-zip/existing_package.zip"
+
+  ignore_source_code_hash = true
 }
 
 ###########

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "aws_lambda_layer_version" "this" {
   compatible_runtimes = length(var.compatible_runtimes) > 0 ? var.compatible_runtimes : [var.runtime]
 
   filename         = local.filename
-  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = var.ignore_source_code_hash ? null : (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "this" {
   package_type                   = var.package_type
 
   filename         = local.filename
-  source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = var.ignore_source_code_hash ? null : (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key
@@ -78,13 +78,6 @@ resource "aws_lambda_function" "this" {
     content {
       local_mount_path = var.file_system_local_mount_path
       arn              = var.file_system_arn
-    }
-  }
-
-  dynamic "lifecycle" {
-    for_each = var.ignore_changes_package ? [true] : []
-    content {
-      ignore_changes = [source_code_hash]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,13 @@ resource "aws_lambda_function" "this" {
     }
   }
 
+  dynamic "lifecycle" {
+    for_each = var.ignore_changes_package ? [true] : []
+    content {
+      ignore_changes = [source_code_hash]
+    }
+  }
+
   tags = var.tags
 
   # Depending on the log group is necessary to allow Terraform to create the log group before AWS can.

--- a/variables.tf
+++ b/variables.tf
@@ -493,8 +493,8 @@ variable "artifacts_dir" {
   default     = "builds"
 }
 
-variable "ignore_changes_package" {
-  description = "Set to true to ignore changes to the function's source code package/hash. Useful when infrastructure and code deployments are managed by separate pipelines"
+variable "ignore_source_code_hash" {
+  description = "Set to true to ignore changes to the function's source code hash. Useful when infrastructure and code deployments are managed by separate pipelines"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -493,6 +493,12 @@ variable "artifacts_dir" {
   default     = "builds"
 }
 
+variable "ignore_changes_package" {
+  description = "Set to true to ignore changes to the function's source code package/hash. Useful when infrastructure and code deployments are managed by separate pipelines"
+  type        = bool
+  default     = false
+}
+
 variable "local_existing_package" {
   description = "The absolute path to an existing zip-file to use"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -494,7 +494,7 @@ variable "artifacts_dir" {
 }
 
 variable "ignore_source_code_hash" {
-  description = "Set to true to ignore changes to the function's source code hash. Useful when infrastructure and code deployments are managed by separate pipelines"
+  description = "Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Description
Ignores changes to the source code hash of the lambda function code to maintain an idempotent terraform build in cases where the application code (lambda package) deployment is managed by an external pipeline / party.

Because the content of `lifecycle` `ignore_changes` lists cannot be dynamically generated, this update simply sets the `aws_lambda_function`'s optional  argument `source_code_hash` to `null` if the new variable `ignore_source_code_hash` is set to `true`.

## Motivation and Context
Allow terraform to manage infrastructure components and application developers to manage the application code

## Breaking Changes
none

## How Has This Been Tested?
- [x] I have tested this against multiple concurrent calls to the module with and without the `ignore_source_code_hash` variable specified / set to `true`