### PR TITLE
fix: Sort directories and files to ensure they are always processed in the same order

### DIFF
--- a/package.py
+++ b/package.py
@@ -140,6 +140,9 @@ def list_files(top_path, log=None):
     results = []
 
     for root, dirs, files in os.walk(top_path, followlinks=True):
+        # Sort directories and files to ensure they are always processed in the same order
+        dirs.sort()
+        files.sort()
         for file_name in files:
             file_path = os.path.join(root, file_name)
             relative_path = os.path.relpath(file_path, top_path)
@@ -211,6 +214,9 @@ def yesno_bool(val):
 
 def emit_dir_content(base_dir):
     for root, dirs, files in os.walk(base_dir, followlinks=True):
+        # Sort directories and files to ensure they are always processed in the same order
+        dirs.sort()
+        files.sort()
         if root != base_dir:
             yield os.path.normpath(root)
         for name in files:
@@ -596,6 +602,9 @@ class ZipContentFilter:
                 yield path
         else:
             for root, dirs, files in os.walk(path, followlinks=True):
+                # Sort directories and files to ensure they are always processed in the same order
+                dirs.sort()
+                files.sort()
                 o, d = norm_path(path, root)
                 # log.info('od: %s %s', o, d)
                 if root != path:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Sort directories and files to ensure they are always processed in the same order during hashing and zip file creation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The order files are walked is not determined by default which can result in different archives created from different workspaces:

```
# diff -y -W 160 <(unzip -vl
.terraform/lambda-start-scheduled-execution-builds/81c20fecbe4e25f6e7dce7b8ee1a151ea6c76e84eeb25cc937f8ddbeeff54777.zip) <(unzip -vl .terraform/lambda-start-scheduled-exe
cution-builds/f6c01d9d2d57cd416967d66704cc421eb24f72aab55da0fd18f7e676ab8a5491.zip)
Archive:  .terraform/lambda-start-scheduled-execution-builds/81c20fecbe4e25f6 | Archive:  .terraform/lambda-start-scheduled-execution-builds/f6c01d9d2d57cd41
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name                   Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----                  --------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 2021-07-05 15:51 00000000  __init__.py         |      901  Defl:N      473  48% 2021-07-12 12:11 cc20a2a7  main.py
     901  Defl:N      473  48% 2021-07-05 17:21 cc20a2a7  main.py             |        0  Defl:N        2   0% 2021-07-12 12:11 00000000  __init__.py
--------          -------  ---                            -------               --------          -------  ---                            -------
     901              475  47%                            2 files                    901              475  47%                            2 files
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with `examples/build-package`.