### PR TITLE
fix: No need to set `aws_s3_bucket_object` `etag` as filename is already a hash of the content

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,6 @@ resource "aws_s3_bucket_object" "lambda_package" {
   acl           = var.s3_acl
   key           = data.external.archive_prepare[0].result.filename
   source        = data.external.archive_prepare[0].result.filename
-  etag          = fileexists(data.external.archive_prepare[0].result.filename) ? filemd5(data.external.archive_prepare[0].result.filename) : null
   storage_class = var.s3_object_storage_class
 
   server_side_encryption = var.s3_server_side_encryption


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There is no need to set the [optional `etag` field of the `aws_s3_bucket_object` resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object#etag) as the filename is a hash of the content that only changes when the actual content changes.

Setting `etag` to a computed MD5 hash of the locally built zip archive used to always trigger changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When building packages on several workspaces, the MD5 sum of the locally built zip archive always changes.
Setting the `TF_RECREATE_MISSING_LAMBDA_PACKAGE` to `false` alone does not resolve that issue.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When package source content changes, the hash of the zip archive changes, it is properly uploaded to S3, and the Lambda is properly updated to use that version.