### PR TITLE
feat: Add `recreate_missing_package` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Q2: How to force recreate deployment package?
 
 Q3: `null_resource.archive[0] must be replaced`
 
-> Answer: This probably mean that zip-archive has been deployed, but is currently absent locally, and it has to be recreated locally. When you run into this issue during CI/CD process (where workspace is clean), you can set environment variable `TF_RECREATE_MISSING_LAMBDA_PACKAGE=false` and run `terraform apply`.
+> Answer: This probably mean that zip-archive has been deployed, but is currently absent locally, and it has to be recreated locally. When you run into this issue during CI/CD process (where workspace is clean) or from multiple workspaces, you can set environment variable `TF_RECREATE_MISSING_LAMBDA_PACKAGE=false` or pass `recreate_missing_package = false` as a parameter to the module and run `terraform apply`.
 
 Q4: What does this error mean - `"We currently do not support adding policies for $LATEST."` ?
 
@@ -715,6 +715,7 @@ No modules.
 | <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | Map of dynamic policy statements to attach to Lambda Function role | `any` | `{}` | no |
 | <a name="input_provisioned_concurrent_executions"></a> [provisioned\_concurrent\_executions](#input\_provisioned\_concurrent\_executions) | Amount of capacity to allocate. Set to 1 or greater to enable, or set to 0 to disable provisioned concurrency. | `number` | `-1` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Whether to publish creation/change as new Lambda Function Version. | `bool` | `false` | no |
+| <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not | `bool` | `true` | no |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_role_force_detach_policies"></a> [role\_force\_detach\_policies](#input\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |

--- a/package.py
+++ b/package.py
@@ -1058,7 +1058,7 @@ def prepare_command(args):
     hash_extra_paths = query.hash_extra_paths
     source_path = query.source_path
     hash_extra = query.hash_extra
-    recreate_missing_package = yesno_bool(args.recreate_missing_package)
+    recreate_missing_package = yesno_bool(args.recreate_missing_package if args.recreate_missing_package is not None else query.recreate_missing_package)
     docker = query.docker
 
     bpm = BuildPlanManager(args, log=log)
@@ -1246,7 +1246,7 @@ def main():
         pattern_comments=yesno_bool(os.environ.get(
             'TF_LAMBDA_PACKAGE_PATTERN_COMMENTS', False)),
         recreate_missing_package=os.environ.get(
-            'TF_RECREATE_MISSING_LAMBDA_PACKAGE', True),
+            'TF_RECREATE_MISSING_LAMBDA_PACKAGE', None),
         log_level=os.environ.get('TF_LAMBDA_PACKAGE_LOG_LEVEL', 'INFO'),
     )
 

--- a/package.tf
+++ b/package.tf
@@ -36,6 +36,8 @@ data "external" "archive_prepare" {
         # "${path.module}/package.py"
       ]
     )
+
+    recreate_missing_package = var.recreate_missing_package
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -588,3 +588,9 @@ variable "docker_pip_cache" {
   type        = any
   default     = null
 }
+
+variable "recreate_missing_package" {
+  description = "Whether to recreate missing Lambda package if it is missing locally or not"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add `recreate_missing_package` parameter in addition to `TF_RECREATE_MISSING_LAMBDA_PACKAGE` environment variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
People can forget defining the `TF_RECREATE_MISSING_LAMBDA_PACKAGE` environment variable to `false` before running `terraform plan` or `terraform apply`, leading to undesired diff.
Adding this as a parameter, we can make sure it is always defined when desired.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

When the `TF_RECREATE_MISSING_LAMBDA_PACKAGE` environment variable is set to `true` or `false`, it takes precedence over the new `recreate_missing_package` parameter which defaults to `true`.