### PR TITLE
feat: Support installing dependencies with poetry

### DIFF
--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -36,8 +36,10 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_lambda_function_from_package"></a> [lambda\_function\_from\_package](#module\_lambda\_function\_from\_package) | ../../ | n/a |
 | <a name="module_lambda_layer"></a> [lambda\_layer](#module\_lambda\_layer) | ../../ | n/a |
 | <a name="module_lambda_layer_pip_requirements"></a> [lambda\_layer\_pip\_requirements](#module\_lambda\_layer\_pip\_requirements) | ../.. | n/a |
+| <a name="module_lambda_layer_poetry"></a> [lambda\_layer\_poetry](#module\_lambda\_layer\_poetry) | ../../ | n/a |
 | <a name="module_package_dir"></a> [package\_dir](#module\_package\_dir) | ../../ | n/a |
 | <a name="module_package_dir_pip_dir"></a> [package\_dir\_pip\_dir](#module\_package\_dir\_pip\_dir) | ../../ | n/a |
+| <a name="module_package_dir_poetry"></a> [package\_dir\_poetry](#module\_package\_dir\_poetry) | ../../ | n/a |
 | <a name="module_package_dir_without_pip_install"></a> [package\_dir\_without\_pip\_install](#module\_package\_dir\_without\_pip\_install) | ../../ | n/a |
 | <a name="module_package_file"></a> [package\_file](#module\_package\_file) | ../../ | n/a |
 | <a name="module_package_file_with_pip_requirements"></a> [package\_file\_with\_pip\_requirements](#module\_package\_file\_with\_pip\_requirements) | ../../ | n/a |

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -17,28 +17,63 @@ resource "random_pet" "this" {
 # Build packages
 #################
 
-# Create zip-archive of a single directory where "pip install" will also be executed (default for python runtime)
+# Create zip-archive of a single directory where "pip install" will also be executed (default for python runtime with requirements.txt present)
 module "package_dir" {
   source = "../../"
 
   create_function = false
 
-  runtime     = "python3.8"
-  source_path = "${path.module}/../fixtures/python3.8-app1"
+  build_in_docker = true
+  runtime         = "python3.8"
+  source_path     = "${path.module}/../fixtures/python3.8-app1"
+  artifacts_dir   = "${path.root}/builds/package_dir/"
 }
 
-# Create zip-archive of a single directory where "pip install" will also be executed (default for python runtime) and set temporary directory for pip install
+# Create zip-archive of a single directory where "pip install" will also be executed (default for python runtime with requirements.txt present) and set temporary directory for pip install
 module "package_dir_pip_dir" {
   source = "../../"
 
   create_function = false
 
-  runtime = "python3.8"
+  build_in_docker = true
+  runtime         = "python3.8"
   source_path = [{
     path             = "${path.module}/../fixtures/python3.8-app1"
     pip_tmp_dir      = "${path.cwd}/../fixtures"
     pip_requirements = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
   }]
+  artifacts_dir = "${path.root}/builds/package_dir_pip_dir/"
+}
+
+# Create zip-archive of a single directory where "poetry install" will also be executed
+module "package_dir_poetry" {
+  source = "../../"
+
+  create_function = false
+
+  build_in_docker = true
+  runtime         = "python3.8"
+  source_path = [
+    {
+      path = "${path.module}/../fixtures/python3.8-app-poetry"
+      patterns = [
+        "!(.*/)*__pycache__/.*",
+        "!_distutils_hack/.*",
+        "!.pytest_cache/.*",
+        "!.venv/.*",
+        "!_virtualenv.pth",
+        "!_virtualenv.py",
+        "!distutils-precedence.pth",
+        "!easy_install.py",
+        "!(pip|pip-.*)(\\.virtualenv|/.*)",
+        "!(pkg_resources|pkg_resources-.*)(\\.virtualenv|/.*)",
+        "!(setuptools|setuptools-.*)(\\.virtualenv|/.*)",
+        "!(wheel|wheel-.*)(\\.virtualenv|/.*)",
+      ]
+      poetry_install = true
+    }
+  ]
+  artifacts_dir = "${path.root}/builds/package_dir_poetry/"
 }
 
 # Create zip-archive of a single directory without running "pip install" (which is default for python runtime)
@@ -241,6 +276,44 @@ module "lambda_layer" {
   build_in_docker = true
   runtime         = "python3.8"
   docker_file     = "${path.module}/../fixtures/python3.8-app1/docker/Dockerfile"
+  docker_image    = "lambci/lambda:build-python3.8"
+  artifacts_dir   = "${path.root}/builds/lambda_layer/"
+}
+
+module "lambda_layer_poetry" {
+  source = "../../"
+
+  create_layer        = true
+  layer_name          = "${random_pet.this.id}-layer-poetry-dockerfile"
+  compatible_runtimes = ["python3.8"]
+
+  source_path = [
+    {
+      path = "${path.module}/../fixtures/python3.8-app-poetry"
+      patterns = [
+        "!(.*/)*__pycache__/.*",
+        "!_distutils_hack/.*",
+        "!.pytest_cache/.*",
+        "!.venv/.*",
+        "!_virtualenv.pth",
+        "!_virtualenv.py",
+        "!distutils-precedence.pth",
+        "!easy_install.py",
+        "!(pip|pip-.*)(\\.virtualenv|/.*)",
+        "!(pkg_resources|pkg_resources-.*)(\\.virtualenv|/.*)",
+        "!(setuptools|setuptools-.*)(\\.virtualenv|/.*)",
+        "!(wheel|wheel-.*)(\\.virtualenv|/.*)",
+      ]
+      poetry_install = true
+    }
+  ]
+  hash_extra = "extra-hash-to-prevent-conflicts-with-module.package_dir"
+
+  build_in_docker = true
+  runtime         = "python3.8"
+  docker_file     = "${path.module}/../fixtures/python3.8-poetry/docker/Dockerfile"
+  docker_image    = "lambci/lambda:build-python3.8"
+  artifacts_dir   = "${path.root}/builds/lambda_layer_poetry/"
 }
 
 #######################

--- a/examples/fixtures/python3.8-app-poetry/ignore_please.txt
+++ b/examples/fixtures/python3.8-app-poetry/ignore_please.txt
@@ -1,0 +1,1 @@
+This file should not be included in archive.

--- a/examples/fixtures/python3.8-app-poetry/index.py
+++ b/examples/fixtures/python3.8-app-poetry/index.py
@@ -1,0 +1,4 @@
+def lambda_handler(event, context):
+    print("Hello from app1!")
+
+    return event

--- a/examples/fixtures/python3.8-app-poetry/poetry.lock
+++ b/examples/fixtures/python3.8-app-poetry/poetry.lock
@@ -1,0 +1,33 @@
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "colorful"
+version = "0.5.4"
+description = "Terminal string styling done right, in Python."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.6"
+content-hash = "65d9f3b221205b259a18285ee8c78c015794fa2e69c66f9ffc836f1758fd594d"
+
+[metadata.files]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+colorful = [
+    {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
+    {file = "colorful-0.5.4.tar.gz", hash = "sha256:86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea"},
+]

--- a/examples/fixtures/python3.8-app-poetry/pyproject.toml
+++ b/examples/fixtures/python3.8-app-poetry/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "python3.8-app-poetry"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+colorful = "^0.5.4"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/examples/fixtures/unittests/pyproject-unknown.toml
+++ b/examples/fixtures/unittests/pyproject-unknown.toml
@@ -1,0 +1,2 @@
+[build-system]
+build-backend = "dummy"

--- a/test_package_toml.py
+++ b/test_package_toml.py
@@ -1,0 +1,10 @@
+from package import get_build_system_from_pyproject_toml
+
+def test_get_build_system_from_pyproject_toml_inexistent():
+    assert get_build_system_from_pyproject_toml("examples/fixtures/inexistent/pyproject.toml") is None
+
+def test_get_build_system_from_pyproject_toml_unknown():
+    assert get_build_system_from_pyproject_toml("examples/fixtures/unittests/pyproject-unknown.toml") is None
+
+def test_get_build_system_from_pyproject_toml_poetry():
+    assert get_build_system_from_pyproject_toml("examples/fixtures/python3.8-app-poetry/pyproject.toml") == "poetry"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py36,py37,py38,py39
+skipsdist=True
+
+[testenv]
+deps = pytest==6.2.4
+commands = pytest


### PR DESCRIPTION
## Description
This PR adds support for installing dependencies with poetry for projects with `pyproject.toml` and optionally `poetry.lock` files.

Marked as draft as poetry [does not currently provide a proper way to isolate installed dependencies from virtualenv](https://github.com/python-poetry/poetry/issues/1937) (pip's `--target` option) so this implementation is kind of a hack that requires manually excluding undesired files from the lambda package.

Submitted the PR early anyway to get feedback.

## Motivation and Context
poetry's is more and more used and has a robust dependency resolver. 

## Breaking Changes
New poetry install step is not enabled by default and requires explicitly setting `poetry_install = True` in the source block.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
rm -rf builds/lambda_layer/ && terraform apply -target module.lambda_layer -auto-approve
rm -rf builds/lambda_layer_poetry/ && terraform apply -target module.lambda_layer_poetry -auto-approve
rm -rf builds/package_dir/ && terraform apply -target module.package_dir -auto-approve
rm -rf builds/package_dir_poetry/ && terraform apply -target module.package_dir_poetry -auto-approve
```