### PR TITLE
feat: Expose ecr tag & scan variables in docker-build module

### DIFF
--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -47,8 +47,8 @@ module "docker_image" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
-| <a name="provider_docker"></a> [docker](#provider\_docker) | 2.15.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.8.0 |
 
 ## Modules
 
@@ -71,6 +71,7 @@ No modules.
 | <a name="input_create_ecr_repo"></a> [create\_ecr\_repo](#input\_create\_ecr\_repo) | Controls whether ECR repository for Lambda image should be created | `bool` | `false` | no |
 | <a name="input_docker_file_path"></a> [docker\_file\_path](#input\_docker\_file\_path) | Path to Dockerfile in source package | `string` | `"Dockerfile"` | no |
 | <a name="input_ecr_repo"></a> [ecr\_repo](#input\_ecr\_repo) | Name of ECR repository to use or to create | `string` | `null` | no |
+| <a name="input_ecr_repo_tags"></a> [ecr\_repo\_tags](#input\_ecr\_repo\_tags) | A map of tags to assign to ECR repository | `map(string)` | `{}` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Indicates whether images are scanned after being pushed to the repository | `bool` | `false` | no |

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -47,8 +47,8 @@ module "docker_image" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
-| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | 2.15.0 |
 
 ## Modules
 
@@ -72,6 +72,8 @@ No modules.
 | <a name="input_docker_file_path"></a> [docker\_file\_path](#input\_docker\_file\_path) | Path to Dockerfile in source package | `string` | `"Dockerfile"` | no |
 | <a name="input_ecr_repo"></a> [ecr\_repo](#input\_ecr\_repo) | Name of ECR repository to use or to create | `string` | `null` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |
+| <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |
+| <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Indicates whether images are scanned after being pushed to the repository | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | Path to folder containing application code | `string` | `null` | no |
 
 ## Outputs

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -31,5 +31,9 @@ resource "docker_registry_image" "this" {
 resource "aws_ecr_repository" "this" {
   count = var.create_ecr_repo ? 1 : 0
 
-  name = var.ecr_repo
+  name                 = var.ecr_repo
+  image_tag_mutability = var.image_tag_mutability
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
 }

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -33,7 +33,10 @@ resource "aws_ecr_repository" "this" {
 
   name                 = var.ecr_repo
   image_tag_mutability = var.image_tag_mutability
+
   image_scanning_configuration {
     scan_on_push = var.scan_on_push
   }
+
+  tags = var.ecr_repo_tags
 }

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -40,3 +40,9 @@ variable "scan_on_push" {
   type        = bool
   default     = false
 }
+
+variable "ecr_repo_tags" {
+  description = "A map of tags to assign to ECR repository"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -27,3 +27,16 @@ variable "docker_file_path" {
   type        = string
   default     = "Dockerfile"
 }
+
+
+variable "image_tag_mutability" {
+  description = "The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`"
+  type        = string
+  default     = "MUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "Indicates whether images are scanned after being pushed to the repository"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description

Simple PR to expose ECR variables related to image tag mutability & scan on push. Defaults are backward compatible.

## Motivation and Context

Give the user the ability to choose lambda image build immutability & vulnerability scanning

## Breaking Changes
N/A

## How Has This Been Tested?

- [x]  I have tested and validated these changes using one or more of the provided examples/* projects
```
cd examples/container-image && \
terraform init && \
terraform apply -target module.docker_image -auto-approve && \
terraform destroy -target module.docker_image -auto-approve
```