### PR TITLE
feat: Add Amazon MQ event source type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 - [With VPC](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/with-vpc) - Create Lambda Function with VPC.
 - [With EFS](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/with-efs) - Create Lambda Function with Elastic File System attached (Terraform 0.13+ is recommended).
 - [Multiple regions](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/multiple-regions) - Create the same Lambda Function in multiple regions with non-conflicting IAM roles and policies.
-- [Event Source Mapping](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/event-source-mapping) - Create Lambda Function with event source mapping configuration (SQS, DynamoDB, and Kinesis).
+- [Event Source Mapping](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/event-source-mapping) - Create Lambda Function with event source mapping configuration (SQS, DynamoDB, Amazon MQ, and Kinesis).
 - [Triggers](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/examples/triggers) - Create Lambda Function with some triggers (eg, Cloudwatch Events, EventBridge).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -580,7 +580,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
@@ -589,7 +589,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
 | <a name="provider_external"></a> [external](#provider\_external) | >= 1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2 |

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/event-source-mapping/README.md
+++ b/examples/event-source-mapping/README.md
@@ -1,6 +1,6 @@
 # Event Source Mapping configuration
 
-Configuration in this directory creates Lambda Function with event source mapping configuration for SQS queue, Kinesis stream, and DynamoDB table.
+Configuration in this directory creates Lambda Function with event source mapping configuration for SQS queue, Kinesis stream, Amazon MQ, and DynamoDB table.
 
 ## Usage
 

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.43"

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws    = ">= 3.27"
+    aws    = ">= 3.43"
     random = ">= 2"
   }
 }

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 3.19"

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.67 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/triggers/versions.tf
+++ b/examples/triggers/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = ">= 2.67"

--- a/main.tf
+++ b/main.tf
@@ -228,6 +228,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   maximum_record_age_in_seconds      = lookup(each.value, "maximum_record_age_in_seconds", null)
   bisect_batch_on_function_error     = lookup(each.value, "bisect_batch_on_function_error", null)
   topics                             = lookup(each.value, "topics", null)
+  queues                             = lookup(each.value, "queues", null)
 
   dynamic "destination_config" {
     for_each = lookup(each.value, "destination_arn_on_failure", null) != null ? [true] : []

--- a/main.tf
+++ b/main.tf
@@ -238,4 +238,12 @@ resource "aws_lambda_event_source_mapping" "this" {
       }
     }
   }
+
+  dynamic "source_access_configuration" {
+    for_each = lookup(each.value, "source_access_configuration", [])
+    content {
+      type = source_access_configuration.value["type"]
+      uri  = source_access_configuration.value["uri"]
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -212,7 +212,7 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 }
 
 resource "aws_lambda_event_source_mapping" "this" {
-  for_each = var.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers ? tomap(var.event_source_mapping) : tomap({})
+  for_each = var.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers ? var.event_source_mapping : tomap({})
 
   function_name = aws_lambda_function.this[0].arn
 

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -115,7 +115,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 
 ## Providers

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = ">= 3.35"

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -99,7 +99,7 @@ module "lambda" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws   = ">= 3.35"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws      = ">= 3.43"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws      = ">= 3.35"
+    aws      = ">= 3.43"
     external = ">= 1"
     local    = ">= 1"
     null     = ">= 2"


### PR DESCRIPTION
## Description

Allow to configure `queues` and `source_access_configuration` properties in [lambda_event_source_mapping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) configuration.

https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-mq.html

## Motivation and Context

Add missing parameters that are required to configure AmazonMQ event source type.

## Breaking Changes

None.

## How Has This Been Tested?

Tested locally by modifying the `examples/event-source-mapping` module to include Amazon MQ event source.