### PR TITLE
fix: Strip leading `./` in S3 key

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ No modules.
 | <a name="input_s3_existing_package"></a> [s3\_existing\_package](#input\_s3\_existing\_package) | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | <a name="input_s3_object_storage_class"></a> [s3\_object\_storage\_class](#input\_s3\_object\_storage\_class) | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
 | <a name="input_s3_object_tags"></a> [s3\_object\_tags](#input\_s3\_object\_tags) | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |
+| <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | Directory name where artifacts should be stored in the S3 bucket. If unset, the path from `artifacts_dir` is used | `string` | `null` | no |
 | <a name="input_s3_server_side_encryption"></a> [s3\_server\_side\_encryption](#input\_s3\_server\_side\_encryption) | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | <a name="input_store_on_s3"></a> [store\_on\_s3](#input\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,6 +27,9 @@ module "lambda_function" {
 
   store_on_s3 = true
   s3_bucket   = module.s3_bucket.s3_bucket_id
+  s3_prefix   = "lambda-builds/"
+
+  artifacts_dir = "${path.root}/.terraform/lambda-builds/"
 
   layers = [
     module.lambda_layer_local.lambda_layer_arn,

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 
   # s3_* - to get package from S3
   s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
-  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? element(concat(data.external.archive_prepare.*.result.filename, [null]), 0) : null)
+  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? replace(element(concat(data.external.archive_prepare.*.result.filename, [null]), 0), "/^.//", "") : null)
   s3_object_version = var.s3_existing_package != null ? lookup(var.s3_existing_package, "version_id", null) : (var.store_on_s3 ? element(concat(aws_s3_bucket_object.lambda_package.*.version_id, [null]), 0) : null)
 
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 
   # s3_* - to get package from S3
   s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
-  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? replace(element(concat(data.external.archive_prepare.*.result.filename, [null]), 0), "/^.//", "") : null)
+  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? var.s3_prefix != null ? format("%s%s", var.s3_prefix, replace(element(concat(data.external.archive_prepare.*.result.filename, [null]), 0), "/^.*//", "")) : replace(element(concat(data.external.archive_prepare.*.result.filename, [null]), 0), "/^\\.//", "") : null)
   s3_object_version = var.s3_existing_package != null ? lookup(var.s3_existing_package, "version_id", null) : (var.store_on_s3 ? element(concat(aws_s3_bucket_object.lambda_package.*.version_id, [null]), 0) : null)
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -493,6 +493,12 @@ variable "artifacts_dir" {
   default     = "builds"
 }
 
+variable "s3_prefix" {
+  description = "Directory name where artifacts should be stored in the S3 bucket. If unset, the path from `artifacts_dir` is used"
+  type        = string
+  default     = null
+}
+
 variable "ignore_source_code_hash" {
   description = "Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately."
   type        = bool


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This change strips the leading `./` in S3 key if `artifacts_dir` is set to something like `${path.root}/mypath/`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this change, this configuration:

```
module "lambda-my-layer" {
  source  = "terraform-aws-modules/lambda/aws"
  version = "2.4.0"

  create_layer = true
  layer_name   = "my-layer"

  runtime         = "python3.8"
  build_in_docker = true

  source_path = [{
    path             = "${path.module}/lambda/my-layer/",
    pip_requirements = true,
    prefix_in_zip    = "python",
  }]

  artifacts_dir = "${path.root}/.terraform/lambda-builds/"

  store_on_s3             = true
  s3_bucket               = aws_s3_bucket.mybuckt.bucket
  s3_object_storage_class = "STANDARD"
}
```

gives the following plan excerpt:

```
  # module.lambda-my-layer.aws_lambda_layer_version.this[0] will be created
  + resource "aws_lambda_layer_version" "this" {
      + arn                         = (known after apply)
      + compatible_runtimes         = [
          + "python3.8",
        ]
      + created_date                = (known after apply)
      + id                          = (known after apply)
      + layer_arn                   = (known after apply)
      + layer_name                  = "my-layer"
      + s3_bucket                   = "s3-my-lambdas-eu-west-3-0123456789012"
      + s3_key                      = "./.terraform/lambda-builds/41c9284df0f8fadfa3437b7a70066400d35ca912bfb089b7d3e01b59870dd077.zip"
      + s3_object_version           = (known after apply)
      + signing_job_arn             = (known after apply)
      + signing_profile_version_arn = (known after apply)
      + source_code_hash            = (known after apply)
      + source_code_size            = (known after apply)
      + version                     = (known after apply)
    }
```

Which fails at apply:

```
│ Error: Error creating lambda layer: InvalidParameterValueException: Error occurred while GetObjectVersion. S3 Error Code: NoSuchVersion. S3 Error Message: The specified version does not exist.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "18230ee0-2112-45d9-850f-0123456789012"
│   },
│   Message_: "Error occurred while GetObjectVersion. S3 Error Code: NoSuchVersion. S3 Error Message: The specified version does not exist.",
│   Type: "User"
│ }
│
│   with module.lambda-cleanup-layer.aws_lambda_layer_version.this[0],
│   on .terraform/modules/lambda-cleanup-layer/main.tf line 93, in resource "aws_lambda_layer_version" "this":
│   93: resource "aws_lambda_layer_version" "this" {
```

With this change, this part of the plan:

```
  # module.lambda-my-layer.aws_lambda_layer_version.this[0] will be created
  + resource "aws_lambda_layer_version" "this" {
      + arn                         = (known after apply)
      + compatible_runtimes         = [
          + "python3.8",
        ]
      + created_date                = (known after apply)
      + id                          = (known after apply)
      + layer_arn                   = (known after apply)
      + layer_name                  = "my-layer"
      + s3_bucket                   = "s3-my-lambdas-eu-west-3-0123456789012"
      + s3_key                      = ".terraform/lambda-builds/41c9284df0f8fadfa3437b7a70066400d35ca912bfb089b7d3e01b59870dd077.zip"
      + s3_object_version           = (known after apply)
      + signing_job_arn             = (known after apply)
      + signing_profile_version_arn = (known after apply)
      + source_code_hash            = (known after apply)
      + source_code_size            = (known after apply)
      + version                     = (known after apply)
    }
```

applies successfully.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This should not be a breaking change as keys with a leading `./` are not accepted by S3.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with `examples/complete` adding the following:

```
diff --git a/examples/complete/main.tf b/examples/complete/main.tf
index 348aab8..4955c76 100644
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,6 +25,8 @@ module "lambda_function" {

   source_path = "${path.module}/../fixtures/python3.8-app1"

+  artifacts_dir = "${path.root}/.terraform/lambda-builds/"
+
   store_on_s3 = true
   s3_bucket   = module.s3_bucket.s3_bucket_id

```

Without the change from this PR:

```
  # module.lambda_function.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      + arn                            = (known after apply)
      + description                    = "My awesome lambda function"
      + function_name                  = (known after apply)
      + handler                        = "index.lambda_handler"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + layers                         = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = true
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.8"
      + s3_bucket                      = (known after apply)
      + s3_key                         = "./.terraform/lambda-builds/09df5667aa77260cb0bac734adccae8d859ac1b014db638db32448b8068cae7c.zip"
      + s3_object_version              = (known after apply)
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "Module" = "lambda1"
        }
      + tags_all                       = {
          + "Module" = "lambda1"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + dead_letter_config {
          + target_arn = (known after apply)
        }

      + environment {
          + variables = {
              + "Hello"      = "World"
              + "Serverless" = "Terraform"
            }
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }
```

With the change from this PR:

```
  # module.lambda_function.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      + arn                            = (known after apply)
      + description                    = "My awesome lambda function"
      + function_name                  = (known after apply)
      + handler                        = "index.lambda_handler"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + layers                         = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = true
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.8"
      + s3_bucket                      = (known after apply)
      + s3_key                         = ".terraform/lambda-builds/09df5667aa77260cb0bac734adccae8d859ac1b014db638db32448b8068cae7c.zip"
      + s3_object_version              = (known after apply)
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "Module" = "lambda1"
        }
      + tags_all                       = {
          + "Module" = "lambda1"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + dead_letter_config {
          + target_arn = (known after apply)
        }

      + environment {
          + variables = {
              + "Hello"      = "World"
              + "Serverless" = "Terraform"
            }
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

```

I have also tested this change with my own terraform configurations.

Note: unlike https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/168, this second PR does not use `dirname()` and `basename()` functions that would not work on Windows.