### PR TITLE
feat: Added docker pip cache support for macOS

### DIFF
--- a/package.py
+++ b/package.py
@@ -981,7 +981,7 @@ def docker_run_command(build_root, command, runtime,
                 '-e', 'SSH_AUTH_SOCK=/tmp/ssh_sock',
             ])
 
-    if platform.system() == 'Linux':
+    if platform.system() in ('Linux', 'Darwin'):
         if pip_cache_dir:
             pip_cache_dir = os.path.abspath(pip_cache_dir)
             docker_cmd.extend([


### PR DESCRIPTION
## Description
Allows the **docker_pip_cache** property to work on macOS. 

## Motivation and Context
Without this, the **docker_pip_cache** property is hard-coded to be ignored unless the host platform is Linux.

## Breaking Changes
No breaking compatibility.

## How Has This Been Tested?
Works great on my Mac, using Docker for Mac, and it's got the M1 chip. I don't see or know why macOS was excluded, unless it was just an oversight in ensuring it didn't happen on Windows.

I could see it not working if the intent was to share a pip cache with the host, but that's not what it's doing. It's just creating a separate directory mapped into the container that gets reused between builds. And that's great! But macOS users would benefit from it, too.