### PR TITLE
feat: add support for additional assume_role_policy statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,14 @@ module "vpc" {
 
 ## Additional IAM policies for Lambda Functions
 
-There are 5 supported ways to attach IAM policies to IAM role used by Lambda Function:
+There are 6 supported ways to attach IAM policies to IAM role used by Lambda Function:
 
 1. `policy_json` - JSON string or heredoc, when `attach_policy_json = true`.
 1. `policy_jsons` - List of JSON strings or heredoc, when `attach_policy_jsons = true` and `number_of_policy_jsons > 0`.
 1. `policy` - ARN of existing IAM policy, when `attach_policy = true`.
 1. `policies` - List of ARNs of existing IAM policies, when `attach_policies = true` and `number_of_policies > 0`.
 1. `policy_statements` - Map of maps to define IAM statements which will be generated as IAM policy. Requires `attach_policy_statements = true`. See `examples/complete` for more information.
+1. `assume_role_policy_statements` - Map of maps to define IAM statements which will be generated as IAM policy for assuming Lambda Function role (trust relationship). See `examples/complete` for more information.
 
 ## Lambda Permissions for allowed triggers
 
@@ -659,6 +660,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_triggers"></a> [allowed\_triggers](#input\_allowed\_triggers) | Map of allowed triggers to create Lambda permissions | `map(any)` | `{}` | no |
 | <a name="input_artifacts_dir"></a> [artifacts\_dir](#input\_artifacts\_dir) | Directory name where artifacts should be stored | `string` | `"builds"` | no |
+| <a name="input_assume_role_policy_statements"></a> [assume\_role\_policy\_statements](#input\_assume\_role\_policy\_statements) | Map of dynamic policy statements for assuming Lambda Function role (trust relationship) | `any` | `{}` | no |
 | <a name="input_attach_async_event_policy"></a> [attach\_async\_event\_policy](#input\_attach\_async\_event\_policy) | Controls whether async event policy should be added to IAM role for Lambda Function | `bool` | `false` | no |
 | <a name="input_attach_cloudwatch_logs_policy"></a> [attach\_cloudwatch\_logs\_policy](#input\_attach\_cloudwatch\_logs\_policy) | Controls whether CloudWatch Logs policy should be added to IAM role for Lambda Function | `bool` | `true` | no |
 | <a name="input_attach_dead_letter_policy"></a> [attach\_dead\_letter\_policy](#input\_attach\_dead\_letter\_policy) | Controls whether SNS/SQS dead letter notification policy should be added to IAM role for Lambda Function | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -65,15 +65,15 @@ module "lambda_function" {
 
   assume_role_policy_statements = {
     account_root = {
-      effect     = "Allow",
-      actions    = ["sts:AssumeRole"],
+      effect  = "Allow",
+      actions = ["sts:AssumeRole"],
       principals = {
         account_principal = {
           type        = "AWS",
           identifiers = ["arn:aws:iam::135367859851:root"]
         }
       }
-      condition  = {
+      condition = {
         stringequals_condition = {
           test     = "StringEquals"
           variable = "sts:ExternalId"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,6 +63,26 @@ module "lambda_function" {
   # Additional policies
   ######################
 
+  assume_role_policy_statements = {
+    account_root = {
+      effect     = "Allow",
+      actions    = ["sts:AssumeRole"],
+      principals = {
+        account_principal = {
+          type        = "AWS",
+          identifiers = ["arn:aws:iam::135367859851:root"]
+        }
+      }
+      condition  = {
+        stringequals_condition = {
+          test     = "StringEquals"
+          variable = "sts:ExternalId"
+          values   = ["12345"]
+        }
+      }
+    }
+  }
+
   attach_policy_json = true
   policy_json        = <<EOF
 {

--- a/iam.tf
+++ b/iam.tf
@@ -52,6 +52,42 @@ data "aws_iam_policy_document" "assume_role" {
       }
     }
   }
+
+  dynamic "statement" {
+    for_each = var.assume_role_policy_statements
+
+    content {
+      sid           = lookup(statement.value, "sid", replace(statement.key, "/[^0-9A-Za-z]*/", ""))
+      effect        = lookup(statement.value, "effect", null)
+      actions       = lookup(statement.value, "actions", null)
+      not_actions   = lookup(statement.value, "not_actions", null)
+
+      dynamic "principals" {
+        for_each = lookup(statement.value, "principals", [])
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+
+      dynamic "not_principals" {
+        for_each = lookup(statement.value, "not_principals", [])
+        content {
+          type        = not_principals.value.type
+          identifiers = not_principals.value.identifiers
+        }
+      }
+
+      dynamic "condition" {
+        for_each = lookup(statement.value, "condition", [])
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
+    }
+  }
 }
 
 resource "aws_iam_role" "lambda" {

--- a/iam.tf
+++ b/iam.tf
@@ -57,10 +57,10 @@ data "aws_iam_policy_document" "assume_role" {
     for_each = var.assume_role_policy_statements
 
     content {
-      sid           = lookup(statement.value, "sid", replace(statement.key, "/[^0-9A-Za-z]*/", ""))
-      effect        = lookup(statement.value, "effect", null)
-      actions       = lookup(statement.value, "actions", null)
-      not_actions   = lookup(statement.value, "not_actions", null)
+      sid         = lookup(statement.value, "sid", replace(statement.key, "/[^0-9A-Za-z]*/", ""))
+      effect      = lookup(statement.value, "effect", null)
+      actions     = lookup(statement.value, "actions", null)
+      not_actions = lookup(statement.value, "not_actions", null)
 
       dynamic "principals" {
         for_each = lookup(statement.value, "principals", [])

--- a/variables.tf
+++ b/variables.tf
@@ -441,6 +441,12 @@ variable "trusted_entities" {
   default     = []
 }
 
+variable "assume_role_policy_statements" {
+  description = "Map of dynamic policy statements for assuming Lambda Function role (trust relationship)"
+  type        = any
+  default     = {}
+}
+
 variable "policy_json" {
   description = "An additional policy document as JSON to attach to the Lambda Function role"
   type        = string


### PR DESCRIPTION
## Description
Add support for additional `assume_role_policy` statements on the `aws_iam_role` via a new variable, `assume_role_policy_statements`.

## Motivation and Context

Fixes #196

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Added `assume_role_policy_statements` to the `complete` example. The observed `assume_role_policy` statements on the  `aws_iam_role` is as expected. As this is a new variable, it should have no impact on the existing code.
