### PR TITLE
feat: allow ignoring updated timestamps of builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Q2: How to force recreate deployment package?
 
 Q3: `null_resource.archive[0] must be replaced`
 
-> Answer: This probably mean that zip-archive has been deployed, but is currently absent locally, and it has to be recreated locally. When you run into this issue during CI/CD process (where workspace is clean) or from multiple workspaces, you can set environment variable `TF_RECREATE_MISSING_LAMBDA_PACKAGE=false` or pass `recreate_missing_package = false` as a parameter to the module and run `terraform apply`.
+> Answer: This probably mean that zip-archive has been deployed, but is currently absent locally, and it has to be recreated locally. When you run into this issue during CI/CD process (where workspace is clean) or from multiple workspaces, you can set environment variable `TF_RECREATE_MISSING_LAMBDA_PACKAGE=false` or pass `recreate_missing_package = false` as a parameter to the module and run `terraform apply`. If only the timestamp differs, you may set `TF_IGNORE_TIMESTAMP=true` or pass `ignore_timestamp = true` as a parameter to the module and run `terraform apply`.
 
 Q4: What does this error mean - `"We currently do not support adding policies for $LATEST."` ?
 
@@ -705,6 +705,7 @@ No modules.
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
 | <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
+| <a name="input_ignore_timestamp"></a> [ignore\_timestamp](#input\_ignore\_timestamp) | Whether to ignore changes to the timestamp of the build. Set to true if you do not have a persistent build directory, such as in CI/CD environments. | `bool` | `false` | no |
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | The working directory for the docker image | `string` | `null` | no |

--- a/package.tf
+++ b/package.tf
@@ -59,7 +59,7 @@ resource "null_resource" "archive" {
 
   triggers = {
     filename  = data.external.archive_prepare[0].result.filename
-    timestamp = data.external.archive_prepare[0].result.timestamp
+    timestamp = var.ignore_timestamp ? 0 : data.external.archive_prepare[0].result.timestamp
   }
 
   provisioner "local-exec" {

--- a/variables.tf
+++ b/variables.tf
@@ -523,6 +523,12 @@ variable "ignore_source_code_hash" {
   default     = false
 }
 
+variable "ignore_timestamp" {
+  description = "Whether to ignore changes to the timestamp of the build. Set to true if you do not have a persistent build directory, such as in CI/CD environments."
+  type        = bool
+  default     = false
+}
+
 variable "local_existing_package" {
   description = "The absolute path to an existing zip-file to use"
   type        = string


### PR DESCRIPTION
## Description
Add a variable to ignore timestamps in the archive null resource. 

## Motivation and Context
When run inside a CI system that doesn't preserve the state of the build directory, then the timestamp is updated on each run and causes a replacement, though the hash remains the same: 

```

  # module.example.null_resource.archive[0] must be replaced
-/+ resource "null_resource" "archive" {
      ~ id       = "12345" -> (known after apply)
      ~ triggers = { # forces replacement
            "filename"  = "builds/deadbeef.zip"
          ~ "timestamp" = "1632965566601180000" -> "1633565134807028000"
        }
    }

```

By allowing the timestamp to be hard set to a static value, then the archive will only be recreated if the hash changes. 
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- execute `terraform plan` in `examples/simple/`
- output: 
  ```
    # module.lambda_function.null_resource.archive[0] will be created
  + resource "null_resource" "archive" {
      + id       = (known after apply)
      + triggers = {
          + "filename"  = "builds/f794f695c5f9c9a81b8d49f360ff0ac8b4d420654198e964aadc3a9a1b2a0e9d.zip"
          + "timestamp" = "1633568575710508200"
        }
    }
  ```
  
- execute `terraform plan` in `examples/simple/` with `ignore_timestamp = true`
- output: 
  ```
      # module.lambda_function.null_resource.archive[0] will be created
  + resource "null_resource" "archive" {
      + id       = (known after apply)
      + triggers = {
          + "filename"  = "builds/f794f695c5f9c9a81b8d49f360ff0ac8b4d420654198e964aadc3a9a1b2a0e9d.zip"
          + "timestamp" = "0"
        }
    }
  ```