### PR TITLE
fix: Raise failure when CodeDeploy deployment fails

### DIFF
--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -63,6 +63,8 @@ while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending"
     sleep 5
 done
 
+${var.aws_cli_command} deploy get-deployment --deployment-id $ID
+
 if [[ $STATUS == "Succeeded" ]]; then
     echo "Deployment succeeded."
 else
@@ -70,12 +72,10 @@ else
     exit 1
 fi
 
-${var.aws_cli_command} deploy get-deployment --deployment-id $ID
-
 %{else}
 
-echo "Deployment started, but wait deployment completion is disabled!"
 ${var.aws_cli_command} deploy get-deployment --deployment-id $ID
+echo "Deployment started, but wait deployment completion is disabled!"
 
 %{endif}
 EOF

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -67,6 +67,7 @@ if [[ $STATUS == "Succeeded" ]]; then
     echo "Deployment succeeded."
 else
     echo "Deployment failed!"
+    exit 1
 fi
 
 ${var.aws_cli_command} deploy get-deployment --deployment-id $ID


### PR DESCRIPTION
closes terraform-aws-modules/terraform-aws-lambda/issues/224

When CodeDeploy fails to finish the deployment, Terraform doesn't realize it and keeps processing. This PR makes the Terraform apply fail whenever the code deploy fails.