### PR TITLE
feat: Added support for Cross-Account ECR for docker-build module

### DIFF
--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -74,6 +74,7 @@ No modules.
 | <a name="input_build_args"></a> [build\_args](#input\_build\_args) | A map of Docker build arguments. | `map(string)` | `{}` | no |
 | <a name="input_create_ecr_repo"></a> [create\_ecr\_repo](#input\_create\_ecr\_repo) | Controls whether ECR repository for Lambda image should be created | `bool` | `false` | no |
 | <a name="input_docker_file_path"></a> [docker\_file\_path](#input\_docker\_file\_path) | Path to Dockerfile in source package | `string` | `"Dockerfile"` | no |
+| <a name="input_ecr_address"></a> [ecr\_address](#input\_ecr\_address) | Address of ECR repository for cross-account container image pulling (optional). Option `create_ecr_repo` must be `false` | `string` | `null` | no |
 | <a name="input_ecr_repo"></a> [ecr\_repo](#input\_ecr\_repo) | Name of ECR repository to use or to create | `string` | `null` | no |
 | <a name="input_ecr_repo_tags"></a> [ecr\_repo\_tags](#input\_ecr\_repo\_tags) | A map of tags to assign to ECR repository | `map(string)` | `{}` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "this" {}
 data "aws_ecr_authorization_token" "token" {}
 
 locals {
-  ecr_address    = var.ecr_address != null ? var.ecr_address : format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.name)
+  ecr_address    = coalesce(var.ecr_address, format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.name))
   ecr_repo       = var.create_ecr_repo ? aws_ecr_repository.this[0].id : var.ecr_repo
   image_tag      = coalesce(var.image_tag, formatdate("YYYYMMDDhhmmss", timestamp()))
   ecr_image_name = format("%v/%v:%v", local.ecr_address, local.ecr_repo, local.image_tag)

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "this" {}
 data "aws_ecr_authorization_token" "token" {}
 
 locals {
-  ecr_address    = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.name)
+  ecr_address    = var.ecr_address != null ? var.ecr_address : format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.name)
   ecr_repo       = var.create_ecr_repo ? aws_ecr_repository.this[0].id : var.ecr_repo
   image_tag      = coalesce(var.image_tag, formatdate("YYYYMMDDhhmmss", timestamp()))
   ecr_image_name = format("%v/%v:%v", local.ecr_address, local.ecr_repo, local.image_tag)

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -4,6 +4,12 @@ variable "create_ecr_repo" {
   default     = false
 }
 
+variable "ecr_address" {
+  description = "Address of ECR repository for cross-account container image pulling (optional). Option `create_ecr_repo` must be `false`"
+  type        = string
+  default     = null
+}
+
 variable "ecr_repo" {
   description = "Name of ECR repository to use or to create"
   type        = string


### PR DESCRIPTION
## Description
Support for Cross-Account ECR for docker-build module

## Motivation and Context
AWS Lambda now supports cross-account container image pulling from Amazon Elastic Container Registry https://aws.amazon.com/about-aws/whats-new/2021/11/aws-lambda-support-cross-account-image-amazon-elastic-container-registry/

## Breaking Changes
None

## How Has This Been Tested?
- I have tested and validated these changes using this example

```terraform
module "docker_image" {
  source = "../../modules/docker-build"

  create_ecr_repo = false
  ecr_address     = "XXXXXXXX.dkr.ecr.eu-central-1.amazonaws.com"
  ecr_repo        = random_pet.this.id
  image_tag       = "1.0"
  source_path     = "context"
  build_args = {
    FOO = "bar"
  }
}
```

