### PR TITLE
feat: Added support for random sleep delay in deploy submodule

### DIFF
--- a/examples/deploy/main.tf
+++ b/examples/deploy/main.tf
@@ -23,13 +23,6 @@ module "lambda_function" {
 
   source_path = "${path.module}/../fixtures/python3.8-app1"
   hash_extra  = "yo1"
-
-  allowed_triggers = {
-    APIGatewayAny = {
-      service    = "apigateway"
-      source_arn = "arn:aws:execute-api:eu-west-1:135367859851:aqnku8akd0/*/*/*"
-    }
-  }
 }
 
 module "alias_refresh" {
@@ -62,6 +55,7 @@ module "deploy" {
   deployment_group_name   = "something"
 
   create_deployment          = true
+  run_deployment             = true
   save_deploy_script         = true
   wait_deployment_completion = true
   force_deploy               = true

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -8,7 +8,7 @@ This module can create AWS CodeDeploy application and deployment group, if neces
 
 During deployment this module does the following:
 1. Create JSON object with required AppSpec configuration. Optionally, you can store deploy script for debug purposes by setting `save_deploy_script = true`.
-1. Run [`aws deploy create-deployment` command](https://docs.aws.amazon.com/cli/latest/reference/deploy/create-deployment.html) if `create_deployment = true` was set
+1. Run [`aws deploy create-deployment` command](https://docs.aws.amazon.com/cli/latest/reference/deploy/create-deployment.html) if `create_deployment = true` and `run_deployment = true` was set.
 1. After deployment is created, it can wait for the completion if `wait_deployment_completion = true`. Be aware, that Terraform will lock the execution and it can fail if it runs for a long period of time. Set this flag for fast deployments (eg, `deployment_config_name = "CodeDeployDefault.LambdaAllAtOnce"`).
 
 
@@ -53,6 +53,7 @@ module "deploy" {
   deployment_group_name   = "something"
 
   create_deployment          = true
+  run_deployment             = true
   wait_deployment_completion = true
 
   triggers = {
@@ -159,7 +160,6 @@ No modules.
 | <a name="input_create_app"></a> [create\_app](#input\_create\_app) | Whether to create new AWS CodeDeploy app | `bool` | `false` | no |
 | <a name="input_create_codedeploy_role"></a> [create\_codedeploy\_role](#input\_create\_codedeploy\_role) | Whether to create new AWS CodeDeploy IAM role | `bool` | `true` | no |
 | <a name="input_create_deployment"></a> [create\_deployment](#input\_create\_deployment) | Create the AWS resources and script for CodeDeploy | `bool` | `false` | no |
-| <a name="input_run_deployment"></a> [run\_deployment](#input\_run\_deployment) | Run AWS CLI command to start the deployment | `bool` | `false` | no |
 | <a name="input_create_deployment_group"></a> [create\_deployment\_group](#input\_create\_deployment\_group) | Whether to create new AWS CodeDeploy Deployment Group | `bool` | `false` | no |
 | <a name="input_current_version"></a> [current\_version](#input\_current\_version) | Current version of Lambda function version to deploy (can't be $LATEST) | `string` | `""` | no |
 | <a name="input_deployment_config_name"></a> [deployment\_config\_name](#input\_deployment\_config\_name) | Name of deployment config to use | `string` | `"CodeDeployDefault.LambdaAllAtOnce"` | no |
@@ -167,7 +167,9 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description to use for the deployment | `string` | `""` | no |
 | <a name="input_force_deploy"></a> [force\_deploy](#input\_force\_deploy) | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name of the Lambda function to deploy | `string` | `""` | no |
+| <a name="input_get_deployment_sleep_timer"></a> [get\_deployment\_sleep\_timer](#input\_get\_deployment\_sleep\_timer) | Adds additional sleep time to get-deployment command to avoid the service throttling | `number` | `5` | no |
 | <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br>  "/bin/bash",<br>  "-c"<br>]</pre> | no |
+| <a name="input_run_deployment"></a> [run\_deployment](#input\_run\_deployment) | Run AWS CLI command to start the deployment | `bool` | `false` | no |
 | <a name="input_save_deploy_script"></a> [save\_deploy\_script](#input\_save\_deploy\_script) | Save deploy script locally | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
 | <a name="input_target_version"></a> [target\_version](#input\_target\_version) | Target version of Lambda function version to deploy | `string` | `""` | no |
@@ -175,7 +177,6 @@ No modules.
 | <a name="input_use_existing_app"></a> [use\_existing\_app](#input\_use\_existing\_app) | Whether to use existing AWS CodeDeploy app | `bool` | `false` | no |
 | <a name="input_use_existing_deployment_group"></a> [use\_existing\_deployment\_group](#input\_use\_existing\_deployment\_group) | Whether to use existing AWS CodeDeploy Deployment Group | `bool` | `false` | no |
 | <a name="input_wait_deployment_completion"></a> [wait\_deployment\_completion](#input\_wait\_deployment\_completion) | Wait until deployment completes. It can take a lot of time and your terraform process may lock execution for long time. | `bool` | `false` | no |
-| <a name="input_get_deployment_sleep_timer"></a> [get\_deployment\_sleep\_timer](#get\_deployment\_sleep\_timer) | Adds additional sleep time to get-deployment command to avoid the service throttling. | `number` | `0` | no |
 
 ## Outputs
 

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -158,7 +158,8 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Controls whether resources should be created | `bool` | `true` | no |
 | <a name="input_create_app"></a> [create\_app](#input\_create\_app) | Whether to create new AWS CodeDeploy app | `bool` | `false` | no |
 | <a name="input_create_codedeploy_role"></a> [create\_codedeploy\_role](#input\_create\_codedeploy\_role) | Whether to create new AWS CodeDeploy IAM role | `bool` | `true` | no |
-| <a name="input_create_deployment"></a> [create\_deployment](#input\_create\_deployment) | Run AWS CLI command to create deployment | `bool` | `false` | no |
+| <a name="input_create_deployment"></a> [create\_deployment](#input\_create\_deployment) | Create the AWS resources and script for CodeDeploy | `bool` | `false` | no |
+| <a name="input_run_deployment"></a> [run\_deployment](#input\_run\_deployment) | Run AWS CLI command to start the deployment | `bool` | `false` | no |
 | <a name="input_create_deployment_group"></a> [create\_deployment\_group](#input\_create\_deployment\_group) | Whether to create new AWS CodeDeploy Deployment Group | `bool` | `false` | no |
 | <a name="input_current_version"></a> [current\_version](#input\_current\_version) | Current version of Lambda function version to deploy (can't be $LATEST) | `string` | `""` | no |
 | <a name="input_deployment_config_name"></a> [deployment\_config\_name](#input\_deployment\_config\_name) | Name of deployment config to use | `string` | `"CodeDeployDefault.LambdaAllAtOnce"` | no |
@@ -174,6 +175,7 @@ No modules.
 | <a name="input_use_existing_app"></a> [use\_existing\_app](#input\_use\_existing\_app) | Whether to use existing AWS CodeDeploy app | `bool` | `false` | no |
 | <a name="input_use_existing_deployment_group"></a> [use\_existing\_deployment\_group](#input\_use\_existing\_deployment\_group) | Whether to use existing AWS CodeDeploy Deployment Group | `bool` | `false` | no |
 | <a name="input_wait_deployment_completion"></a> [wait\_deployment\_completion](#input\_wait\_deployment\_completion) | Wait until deployment completes. It can take a lot of time and your terraform process may lock execution for long time. | `bool` | `false` | no |
+| <a name="input_get_deployment_sleep_timer"></a> [get\_deployment\_sleep\_timer](#get\_deployment\_sleep\_timer) | Adds additional sleep time to get-deployment command to avoid the service throttling. | `number` | `0` | no |
 
 ## Outputs
 

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -60,7 +60,10 @@ while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending"
         --deployment-id $ID \
         --output text \
         --query '[deploymentInfo.status]')
-    sleep 5
+
+    SLEEP_TIME=$(( $RANDOM % 10 ) + ${var.get_deployment_sleep_timer})
+    echo "Sleeping for: $SLEEP_TIME Seconds"
+    sleep $SLEEP_TIME
 done
 
 ${var.aws_cli_command} deploy get-deployment --deployment-id $ID
@@ -106,7 +109,7 @@ resource "local_file" "deploy_script" {
 }
 
 resource "null_resource" "deploy" {
-  count = var.create && var.create_deployment ? 1 : 0
+  count = var.run_deployment ? 1 : 0
 
   triggers = {
     appspec_sha256 = local.appspec_sha256

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -61,7 +61,7 @@ while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending"
         --output text \
         --query '[deploymentInfo.status]')
 
-    SLEEP_TIME=$(( $RANDOM % 10 ) + ${var.get_deployment_sleep_timer})
+    SLEEP_TIME=$(( $RANDOM % 5 ) + ${var.get_deployment_sleep_timer})
     echo "Sleeping for: $SLEEP_TIME Seconds"
     sleep $SLEEP_TIME
 done

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -109,7 +109,7 @@ resource "local_file" "deploy_script" {
 }
 
 resource "null_resource" "deploy" {
-  count = var.run_deployment ? 1 : 0
+  count = var.create && var.create_deployment && var.run_deployment ? 1 : 0
 
   triggers = {
     appspec_sha256 = local.appspec_sha256

--- a/modules/deploy/variables.tf
+++ b/modules/deploy/variables.tf
@@ -161,7 +161,13 @@ variable "save_deploy_script" {
 }
 
 variable "create_deployment" {
-  description = "Run AWS CLI command to create deployment"
+  description = "Create the AWS resources and script for CodeDeploy"
+  type        = bool
+  default     = false
+}
+
+variable "run_deployment" {
+  description = "Run AWS CLI command to start the deployment"
   type        = bool
   default     = false
 }
@@ -210,4 +216,10 @@ variable "attach_triggers_policy" {
   description = "Whether to attach SNS policy to CodeDeploy role when triggers are defined"
   type        = bool
   default     = false
+}
+
+variable "get_deployment_sleep_timer" {
+  description = "Adds additional sleep time to get-deployment command to avoid the service throttling"
+  type        = number
+  default     = 0
 }

--- a/modules/deploy/variables.tf
+++ b/modules/deploy/variables.tf
@@ -221,5 +221,5 @@ variable "attach_triggers_policy" {
 variable "get_deployment_sleep_timer" {
   description = "Adds additional sleep time to get-deployment command to avoid the service throttling"
   type        = number
-  default     = 0
+  default     = 5
 }


### PR DESCRIPTION
## Description
Adding here 2 minor tweaks to the deploy sub-module that I found useful.

## Motivation and Context
1) When I deploy multiple lambdas and use the `wait_deployment_completion` the AWS is throttling the CLI calls and the script fails. Here, I'm introducing the `get_deployment_sleep_timer` variable that it can increase the sleep time. Also the sleep time is a random number between `(0  and 10) + ${get_deployment_sleep_timer}`.

2) I want to separate the infrastructure deployment from the lambda lambda function release via CodeDeploy. The motivation behind this is to capture any issues that introduced by the infrastructure changes.
An example is, you change the permissions for a resource that a lambda function use, the old version immediately louses access and you wait until the traffic switches to the new version that has all the right permissions. So the `run_deployment` now will trigger the bash script otherwise deploy the infra, save the script and run it whenever you want.

## Breaking Changes
In order to run the deployment bash script now you need to set `run_deployment = true`

## How Has This Been Tested?
- Both features are tested in a private project. Please let me know that evidence I should provide here.
