### PR TITLE
fix the sleep_time variable

### DIFF
--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -61,7 +61,8 @@ while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending"
         --output text \
         --query '[deploymentInfo.status]')
 
-    SLEEP_TIME=$(( $RANDOM % 5 ) + ${var.get_deployment_sleep_timer})
+    SLEEP_TIME=$((( $RANDOM % 5 ) + ${var.get_deployment_sleep_timer}))
+
     echo "Sleeping for: $SLEEP_TIME Seconds"
     sleep $SLEEP_TIME
 done


### PR DESCRIPTION
## Description
Fix the following error when `wait_deployment_completion = true` 

```
│ Status: InProgress...
│ /bin/bash: command substitution: line 29: syntax error near unexpected token `+'
│ /bin/bash: command substitution: line 29: `( $RANDOM % 5 ) + 20'
```
## Test
Tested it in my private repo
```
module.demo.null_resource.deploy[0] (local-exec): Status: Created...
module.demo.null_resource.deploy[0] (local-exec): Sleeping for: 22 Seconds
module.demo.null_resource.deploy[0]: Still creating... [10s elapsed]
module.demo.null_resource.deploy[0]: Still creating... [20s elapsed]
module.demo.null_resource.deploy[0] (local-exec): Status: InProgress...
module.demo.null_resource.deploy[0] (local-exec): Sleeping for: 22 Seconds
module.demo.null_resource.deploy[0]: Still creating... [30s elapsed]
module.demo.null_resource.deploy[0]: Still creating... [40s elapsed]
```