### PR TITLE
feat: Add ECR Lifecycle Policy Option to docker-build module

### DIFF
--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -38,4 +38,22 @@ module "docker_image" {
   build_args = {
     FOO = "bar"
   }
+  ecr_repo_lifecycle_policy = <<EOF
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Keep only the last 2 images",
+      "selection": {
+        "tagStatus": "any",
+        "countType": "imageCountMoreThan",
+        "countNumber": 2
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}
+EOF
 }

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -61,6 +61,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [docker_registry_image.this](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -76,6 +77,7 @@ No modules.
 | <a name="input_docker_file_path"></a> [docker\_file\_path](#input\_docker\_file\_path) | Path to Dockerfile in source package | `string` | `"Dockerfile"` | no |
 | <a name="input_ecr_address"></a> [ecr\_address](#input\_ecr\_address) | Address of ECR repository for cross-account container image pulling (optional). Option `create_ecr_repo` must be `false` | `string` | `null` | no |
 | <a name="input_ecr_repo"></a> [ecr\_repo](#input\_ecr\_repo) | Name of ECR repository to use or to create | `string` | `null` | no |
+| <a name="input_ecr_repo_lifecycle_policy"></a> [ecr\_repo\_lifecycle\_policy](#input\_ecr\_repo\_lifecycle\_policy) | A JSON formatted ECR lifecycle policy to automate the cleaning up of unused images. | `string` | `null` | no |
 | <a name="input_ecr_repo_tags"></a> [ecr\_repo\_tags](#input\_ecr\_repo\_tags) | A map of tags to assign to ECR repository | `map(string)` | `{}` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -43,7 +43,7 @@ resource "aws_ecr_repository" "this" {
 }
 
 resource "aws_ecr_lifecycle_policy" "this" {
-  count = length(var.ecr_repo_lifecycle_policy) > 0 ? 1 : 0
+  count = var.ecr_repo_lifecycle_policy != null ? 1 : 0
 
   policy     = var.ecr_repo_lifecycle_policy
   repository = local.ecr_repo

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -41,3 +41,10 @@ resource "aws_ecr_repository" "this" {
 
   tags = var.ecr_repo_tags
 }
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  count = length(var.ecr_repo_lifecycle_policy) > 0 ? 1 : 0
+
+  policy     = var.ecr_repo_lifecycle_policy
+  repository = local.ecr_repo
+}

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -62,5 +62,5 @@ variable "build_args" {
 variable "ecr_repo_lifecycle_policy" {
   description = "A JSON formatted ECR lifecycle policy to automate the cleaning up of unused images."
   type        = string
-  default     = ""
+  default     = null
 }

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -58,3 +58,9 @@ variable "build_args" {
   type        = map(string)
   default     = {}
 }
+
+variable "ecr_repo_lifecycle_policy" {
+  description = "A JSON formatted ECR lifecycle policy to automate the cleaning up of unused images."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Description
Let users add ECR lifecycle policy rules to automate the cleaning up of unused images generated by the `docker-build` module.

## Motivation and Context
I use this module to build and publish many Docker Images to ECR and I want to be able to easily delete unneeded Docker Images. Since this module is the one building and publishing the Docker Images to ECR it seems best to extend the module to also support the JSON ECR lifecycle policy document. 

## Breaking Changes
This is not a breaking change and is only added non-breaking functionality to the module. 

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
```hcl
// examples/container-image/main.tf

module "docker_image" {
  source = "../../modules/docker-build"

  create_ecr_repo = true
  ecr_repo        = random_pet.this.id
  image_tag       = "1.0"
  source_path     = "context"
  build_args = {
    FOO = "bar"
  }
  ecr_repo_lifecycle_policy = <<EOF
{
  "rules": [
    {
      "rulePriority": 1,
      "description": "Keep only the last 2 images",
      "selection": {
        "tagStatus": "any",
        "countType": "imageCountMoreThan",
        "countNumber": 2
      },
      "action": {
        "type": "expire"
      }
    }
  ]
}
EOF
}

```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
