### PR TITLE
feat: Allow the use of third party images to build dependencies

### DIFF
--- a/package.py
+++ b/package.py
@@ -971,13 +971,15 @@ def docker_run_command(build_root, command, runtime,
     if platform.system() not in ('Linux', 'Darwin'):
         raise RuntimeError("Unsupported platform for docker building")
 
-    docker_cmd = ['docker', 'run', '--rm']
+    workdir = '/var/task'
+
+    docker_cmd = ['docker', 'run', '--rm', '-w', workdir]
 
     if interactive:
         docker_cmd.append('-it')
 
     bind_path = os.path.abspath(build_root)
-    docker_cmd.extend(['-v', "{}:/var/task:z".format(bind_path)])
+    docker_cmd.extend(['-v', "{}:{}:z".format(bind_path, workdir)])
 
     home = os.environ['HOME']
     docker_cmd.extend([


### PR DESCRIPTION
## Description
Allow the use of third party images to build dependencies other that `lambci` images.

## Motivation and Context
The current implementation requires docker images that have a worker pointing to `/var/task`, since it forces the mount point to that location. It prevents the user to user an official image or any other image that does has the working directory in `/var/task`.

If you try to create a lambda for example, using `build_in_docker = true` it will fail because the workdir is empty. And if you try to use `pip_requirements` to install the requirements, it will throw an error saying it couldn't find `requirements.txt` - because the workdir is not the same as the mount point.

With this change we set the workdir to `/var/task` in the `docker run` command, so no matter which image you use, the mount point and the workdir will be the same.

We've been using this change in our company and it works with the the default image and official python images.

It could be a better solution to also allow the user to specify a custom workdir. But this is an easier and safe solution for now.

## Breaking Changes
There's no breaking changes. This

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

I've tested the `container-image` and `build-package` examples. We also have been using this code to deploy production code in our company. Using both the default images as well as official images.
