### PR TITLE
Added handling for archive_filename when create is false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_partition" "current" {}
 
 locals {
-  archive_filename    = element(concat(data.external.archive_prepare.*.result.filename, [null]), 0)
+  archive_filename    = var.create ? element(concat(data.external.archive_prepare.*.result.filename, [null]), 0) : ""
   archive_was_missing = element(concat(data.external.archive_prepare.*.result.was_missing, [false]), 0)
 
   # Use a generated filename to determine when the source code has changed.


### PR DESCRIPTION
## Description
When retrieving the filename of the Lambda archive, set value to blank string if create is false.

## Motivation and Context
#251 

## Breaking Changes
None.

## How Has This Been Tested?
Edit any of the examples by adding create = false and then run terraform plan.
