### PR TITLE
feat: Changing sorting of trusted entities for lambda_at_edge = true

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@ locals {
 
   # IAM Role trusted entities is a list of any (allow strings (services) and maps (type+identifiers))
   trusted_entities_services = distinct(compact(concat(
-    slice(["lambda.amazonaws.com", "edgelambda.amazonaws.com"], 0, var.lambda_at_edge ? 2 : 1),
+    slice(["edgelambda.amazonaws.com", "lambda.amazonaws.com"], 0, var.lambda_at_edge ? 2 : 1),
     [for service in var.trusted_entities : try(tostring(service), "")]
   )))
 


### PR DESCRIPTION
Changing sorting of trusted entities for lambda_at_edge switch

## Description
Changed the sorting of trusted entities

## Motivation and Context
If lambda_at_edge = true, terraform swaps out the trusted entities

```
  # module.lambda_origin_response["blahblah"].aws_iam_role.lambda[0] has changed
  ~ resource "aws_iam_role" "lambda" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          ~ Service = [
                              - "lambda.amazonaws.com",
                                "edgelambda.amazonaws.com",
                              + "lambda.amazonaws.com",
                            ]
                        }
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
```

## How Has This Been Tested?
- [ ] After the change, the sorting equals the sorting returned from the AWS API (I verified in conjunction with Lambda@Egde & CloudFront)