### PR TITLE
feat: Accept new arguments `function_response_types` in `aws_lambda_event_source_mapping`

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,19 +592,19 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.66 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | >= 1 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66 |
-| <a name="provider_external"></a> [external](#provider\_external) | >= 1 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_external"></a> [external](#provider\_external) | >= 1.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 1.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules
 

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -24,7 +24,8 @@ module "lambda_function" {
 
   event_source_mapping = {
     sqs = {
-      event_source_arn = aws_sqs_queue.this.arn
+      event_source_arn        = aws_sqs_queue.this.arn
+      function_response_types = ["ReportBatchItemFailures"]
     }
     dynamodb = {
       event_source_arn           = aws_dynamodb_table.this.stream_arn

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.43"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.69"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -237,6 +237,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   bisect_batch_on_function_error     = lookup(each.value, "bisect_batch_on_function_error", null)
   topics                             = lookup(each.value, "topics", null)
   queues                             = lookup(each.value, "queues", null)
+  function_response_types            = lookup(each.value, "function_response_types", null)
 
   dynamic "destination_config" {
     for_each = lookup(each.value, "destination_arn_on_failure", null) != null ? [true] : []

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,21 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws      = ">= 3.66"
-    external = ">= 1"
-    local    = ">= 1"
-    null     = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.69"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 1.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

I added an optional argument in `aws_lambda_event_source_mapping` definition.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/254

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes that the new line I added in this PR is optional argument.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I used `examples/event-source-mapping/main.tf` for testing.
First I applied it before this change, and then I added a new configuration in the example such as below.

```
event_source_mapping = {
    sqs = {
      event_source_arn = aws_sqs_queue.this.arn
      function_response_types = ["ReportBatchItemFailures"] # added this line
    }
    dynamodb = {
  ...
```

After that, I applied again and got as below.
```
Terraform will perform the following actions:

  # module.lambda_function.aws_lambda_event_source_mapping.this["sqs"] will be updated in-place
  ~ resource "aws_lambda_event_source_mapping" "this" {
      ~ function_response_types            = [
          + "ReportBatchItemFailures",
        ]
        id                                 = "e535db8a-1f87-4c5c-a0c7-611b6eaea024"
        # (17 unchanged attributes hidden)
    }

  # module.lambda_function.null_resource.archive[0] must be replaced
-/+ resource "null_resource" "archive" {
      ~ id       = "5022921647598251107" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "timestamp" = "1642698462516710000" -> "1642759069961922000"
            # (1 unchanged element hidden)
        }
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```