### PR TITLE
fix: Removed hard-coded AWS account id in examples

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,6 +9,8 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_caller_identity" "current" {}
+
 ####################################################
 # Lambda Function (building locally, storing on S3,
 # set allowed triggers, set policies)
@@ -51,15 +53,15 @@ module "lambda_function" {
   allowed_triggers = {
     APIGatewayAny = {
       service    = "apigateway"
-      source_arn = "arn:aws:execute-api:eu-west-1:135367859851:aqnku8akd0/*/*/*"
+      source_arn = "arn:aws:execute-api:eu-west-1:${data.aws_caller_identity.current.account_id}:aqnku8akd0/*/*/*"
     },
     APIGatewayDevPost = {
       service    = "apigateway"
-      source_arn = "arn:aws:execute-api:eu-west-1:135367859851:aqnku8akd0/dev/POST/*"
+      source_arn = "arn:aws:execute-api:eu-west-1:${data.aws_caller_identity.current.account_id}:aqnku8akd0/dev/POST/*"
     },
     OneRule = {
       principal  = "events.amazonaws.com"
-      source_arn = "arn:aws:events:eu-west-1:135367859851:rule/RunDaily"
+      source_arn = "arn:aws:events:eu-west-1:${data.aws_caller_identity.current.account_id}:rule/RunDaily"
     }
   }
 
@@ -74,7 +76,7 @@ module "lambda_function" {
       principals = {
         account_principal = {
           type        = "AWS",
-          identifiers = ["arn:aws:iam::135367859851:root"]
+          identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
         }
       }
       condition = {


### PR DESCRIPTION
Removed hard-coded AWS account ID from examples/complete and added data resource to lookup current AWS account

## Description
Remove hard-coded AWS account ID from examples/complete and added data resource to lookup current AWS account

## Motivation and Context
Unable to build the examples/complete  main.tf because the AWS account id is hard-coded.

## Breaking Changes
No


## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

