### PR TITLE
feat: Added support for self managed kafka in event source mapping

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -54,6 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_sqs_queue.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -63,6 +63,35 @@ module "lambda_function" {
         }
       ]
     }
+    # self_managed_kafka = {
+    #   batch_size        = 1
+    #   starting_position = "TRIM_HORIZON"
+    #   topics = [
+    #     var.topic_name
+    #   ]
+    #   self_managed_event_source = [
+    #     {
+    #       endpoints = {
+    #         KAFKA_BOOTSTRAP_SERVERS = data.aws_msk_cluster.kafka.bootstrap_brokers_sasl_scram
+    #       }
+    #     }
+    #   ]
+    #   source_access_configuration = concat([
+    #     {
+    #       type = "SASL_SCRAM_512_AUTH",
+    #       uri  = data.aws_secretsmanager_secret.kafka_scram_sasl.arn
+    #     },
+    #     {
+    #       type = "VPC_SECURITY_GROUP",
+    #       uri  = "security_group:${security_group_id}"
+    #     }
+    #     ], [for subnet in data.aws_subnet.vpc_lambda_subnets :
+    #     {
+    #       type = "VPC_SUBNET"
+    #       uri  = "subnet:${subnet.id}"
+    #     }
+    #   ])
+    # }
   }
 
   allowed_triggers = {

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -63,35 +63,32 @@ module "lambda_function" {
         }
       ]
     }
-    # self_managed_kafka = {
-    #   batch_size        = 1
-    #   starting_position = "TRIM_HORIZON"
-    #   topics = [
-    #     var.topic_name
-    #   ]
-    #   self_managed_event_source = [
-    #     {
-    #       endpoints = {
-    #         KAFKA_BOOTSTRAP_SERVERS = data.aws_msk_cluster.kafka.bootstrap_brokers_sasl_scram
-    #       }
-    #     }
-    #   ]
-    #   source_access_configuration = concat([
-    #     {
-    #       type = "SASL_SCRAM_512_AUTH",
-    #       uri  = data.aws_secretsmanager_secret.kafka_scram_sasl.arn
-    #     },
-    #     {
-    #       type = "VPC_SECURITY_GROUP",
-    #       uri  = "security_group:${security_group_id}"
-    #     }
-    #     ], [for subnet in data.aws_subnet.vpc_lambda_subnets :
-    #     {
-    #       type = "VPC_SUBNET"
-    #       uri  = "subnet:${subnet.id}"
-    #     }
-    #   ])
-    # }
+    #    self_managed_kafka = {
+    #      batch_size        = 1
+    #      starting_position = "TRIM_HORIZON"
+    #      topics            = ["topic1", "topic2"]
+    #      self_managed_event_source = [
+    #        {
+    #          endpoints = {
+    #            KAFKA_BOOTSTRAP_SERVERS = "kafka1.example.com:9092,kafka2.example.com:9092"
+    #          }
+    #        }
+    #      ]
+    #      source_access_configuration = [
+    #        {
+    #          type = "SASL_SCRAM_512_AUTH",
+    #          uri  = "SECRET_AUTH_INFO"
+    #        },
+    #        {
+    #          type = "VPC_SECURITY_GROUP",
+    #          uri  = "security_group:sg-12345678"
+    #        },
+    #        {
+    #          type = "VPC_SUBNET"
+    #          uri  = "subnet:subnet-12345678"
+    #        }
+    #      ]
+    #    }
   }
 
   allowed_triggers = {

--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,7 @@ resource "aws_lambda_event_source_mapping" "this" {
 
   function_name = aws_lambda_function.this[0].arn
 
-  event_source_arn = lookup(each.value, "event_source_arn", null)
+  event_source_arn = try(each.value.event_source_arn, null)
 
   batch_size                         = try(each.value.batch_size, null)
   maximum_batching_window_in_seconds = try(each.value.maximum_batching_window_in_seconds, null)
@@ -256,7 +256,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   }
 
   dynamic "self_managed_event_source" {
-    for_each = lookup(each.value, "self_managed_event_source", [])
+    for_each = try(each.value.self_managed_event_source, [])
     content {
       endpoints = self_managed_event_source.value.endpoints
     }

--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,7 @@ resource "aws_lambda_event_source_mapping" "this" {
 
   function_name = aws_lambda_function.this[0].arn
 
-  event_source_arn = each.value.event_source_arn
+  event_source_arn = lookup(each.value, "event_source_arn", null)
 
   batch_size                         = lookup(each.value, "batch_size", null)
   maximum_batching_window_in_seconds = lookup(each.value, "maximum_batching_window_in_seconds", null)
@@ -246,6 +246,13 @@ resource "aws_lambda_event_source_mapping" "this" {
       on_failure {
         destination_arn = each.value["destination_arn_on_failure"]
       }
+    }
+  }
+
+  dynamic "self_managed_event_source" {
+    for_each = lookup(each.value, "self_managed_event_source", [])
+    content {
+      endpoints = self_managed_event_source.value.endpoints
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Resolve #277  issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

need to kafka brokers. you can use AWS MSK.

```tf
self_managed_kafka = {
  batch_size = 100
  starting_position = "TRIM_HORIZON"
  topics = [
    "example-topic-v1"
  ]
  self_managed_event_source = [
    {
      endpoints = {
        KAFKA_BOOTSTRAP_SERVERS = "kafka1.example.com:9092,kafka2.example.com:9092"
      }
    }
  ]
  source_access_configuration = [
    {
      type =  "SASL_SCRAM_512_AUTH",
      uri = "SECRET_AUTH_INFO"
    },
    {
      type = "VPC_SUBNET",
      uri = "subnet:subnet-example"
    },
    {
      type = "VPC_SUBNET",
      uri = "subnet:subnet-example"
    },
    {
      type = "VPC_SECURITY_GROUP",
      uri = "security_group:sg-example"
    }
  ]
}
```
