### PR TITLE
Validate to not use ENV with Lambda@Edge

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,10 @@ locals {
 
 }
 
+resource "null_resource" "edge_with_env_check" {
+  count = var.lambda_at_edge && length(var.environment_variables) > 0 ? "ERROR: Lambda@Edge does not support environment variables" : 1
+}
+
 resource "aws_lambda_function" "this" {
   count = var.create && var.create_function && !var.create_layer ? 1 : 0
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This validates the `environment_variables` variable and throws an error if `lambda_at_edge == true`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lambda@Edge does not support environment variables. Let the user know before applying that they are doing something unsupported.


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
I don't think it's a breaking version as this just introduces the error on `plan` instead of `apply`

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tried running plans for lambdas with and without environment_variables, with and without lamdba_at_edge enabled
