### PR TITLE
feat: Bump terraform aws provider required version to v4.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
   # s3_* - to get package from S3
   s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
   s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? var.s3_prefix != null ? format("%s%s", var.s3_prefix, replace(local.archive_filename_string, "/^.*//", "")) : replace(local.archive_filename_string, "/^\\.//", "") : null)
-  s3_object_version = var.s3_existing_package != null ? lookup(var.s3_existing_package, "version_id", null) : (var.store_on_s3 ? try(aws_s3_bucket_object.lambda_package[0].version_id, null) : null)
+  s3_object_version = var.s3_existing_package != null ? lookup(var.s3_existing_package, "version_id", null) : (var.store_on_s3 ? try(aws_s3_object.lambda_package[0].version_id, null) : null)
 
 }
 
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "this" {
   # When a lambda function is invoked, AWS creates the log group automatically if it doesn't exist yet.
   # Without the dependency, this can result in a race condition if the lambda function is invoked before
   # Terraform can create the log group.
-  depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package, aws_cloudwatch_log_group.lambda]
+  depends_on = [null_resource.archive, aws_s3_object.lambda_package, aws_cloudwatch_log_group.lambda]
 }
 
 resource "aws_lambda_layer_version" "this" {
@@ -117,10 +117,10 @@ resource "aws_lambda_layer_version" "this" {
   s3_key            = local.s3_key
   s3_object_version = local.s3_object_version
 
-  depends_on = [null_resource.archive, aws_s3_bucket_object.lambda_package]
+  depends_on = [null_resource.archive, aws_s3_object.lambda_package]
 }
 
-resource "aws_s3_bucket_object" "lambda_package" {
+resource "aws_s3_object" "lambda_package" {
   count = local.create && var.store_on_s3 && var.create_package ? 1 : 0
 
   bucket        = var.s3_bucket

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 4.0"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
## Description
Replace `aws_s3_bucket_object` with `aws_s3_object` and increase the aws provider required version to v4.x.

## Motivation and Context
Since the release of the aws terraform provider v4, the `aws_s3_bucket_object` resource has been deprecated, replaced by `aws_s3_object`.

## Breaking Changes
Yes, the aws terraform provider version needs to be >= 4.0

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
