### PR TITLE
fix: Alias Module: Move lifecycle hook that ignores lambda_version from wi…

### DIFF
--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -26,6 +26,10 @@ resource "aws_lambda_alias" "no_refresh" {
       additional_version_weights = var.routing_additional_version_weights
     }
   }
+
+  lifecycle {
+    ignore_changes = [function_version]
+  }
 }
 
 resource "aws_lambda_alias" "with_refresh" {
@@ -43,10 +47,6 @@ resource "aws_lambda_alias" "with_refresh" {
     content {
       additional_version_weights = var.routing_additional_version_weights
     }
-  }
-
-  lifecycle {
-    ignore_changes = [function_version]
   }
 }
 


### PR DESCRIPTION
## Description
Fixes issue described in #281 

## Motivation and Context
This change will all `with_refresh` to behave as expected.

## Breaking Changes
This will cause anyone who have coded around this issue (uses `no_refresh` instead of `with_refresh`) to no longer have their alias refreshed with the passed in version

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
-- https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/master/examples/alias/main.tf
