### PR TITLE
fix: Added support for keep_remotely in docker-build submodule

### DIFF
--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -81,6 +81,7 @@ No modules.
 | <a name="input_ecr_repo_tags"></a> [ecr\_repo\_tags](#input\_ecr\_repo\_tags) | A map of tags to assign to ECR repository | `map(string)` | `{}` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |
+| <a name="input_keep_remotely"></a> [keep\_remotely](#input\_keep\_remotely) | If `true`, then the Docker image won't be deleted on destroy operation. If this is `false`, it will delete the image from the docker registry on destroy operation. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Indicates whether images are scanned after being pushed to the repository | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | Path to folder containing application code | `string` | `null` | no |
 

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -44,14 +44,14 @@ module "docker_image" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 2.8.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 2.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
-| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.8.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.12 |
 
 ## Modules
 
@@ -81,7 +81,7 @@ No modules.
 | <a name="input_ecr_repo_tags"></a> [ecr\_repo\_tags](#input\_ecr\_repo\_tags) | A map of tags to assign to ECR repository | `map(string)` | `{}` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |
-| <a name="input_keep_remotely"></a> [keep\_remotely](#input\_keep\_remotely) | If `true`, then the Docker image won't be deleted on destroy operation. If this is `false`, it will delete the image from the docker registry on destroy operation. Defaults to `false`. | `bool` | `false` | no |
+| <a name="input_keep_remotely"></a> [keep\_remotely](#input\_keep\_remotely) | Whether to keep Docker image in the remote registry on destroy operation. | `bool` | `false` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Indicates whether images are scanned after being pushed to the repository | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | Path to folder containing application code | `string` | `null` | no |
 

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -27,6 +27,8 @@ resource "docker_registry_image" "this" {
     dockerfile = var.docker_file_path
     build_args = var.build_args
   }
+
+  keep_remotely = var.keep_remotely
 }
 
 resource "aws_ecr_repository" "this" {

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -66,7 +66,7 @@ variable "ecr_repo_lifecycle_policy" {
 }
 
 variable "keep_remotely" {
-  description = "If `true`, then the Docker image won't be deleted on destroy operation. If this is `false`, it will delete the image from the docker registry on destroy operation. Defaults to `false`."
+  description = "Whether to keep Docker image in the remote registry on destroy operation."
   type        = bool
   default     = false
 }

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -64,3 +64,9 @@ variable "ecr_repo_lifecycle_policy" {
   type        = string
   default     = null
 }
+
+variable "keep_remotely" {
+  description = "If `true`, then the Docker image won't be deleted on destroy operation. If this is `false`, it will delete the image from the docker registry on destroy operation. Defaults to `false`."
+  type        = bool
+  default     = false
+}

--- a/modules/docker-build/versions.tf
+++ b/modules/docker-build/versions.tf
@@ -2,10 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.35"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.35"
+    }
     docker = {
       source  = "kreuzwerker/docker"
-      version = ">= 2.8.0"
+      version = ">= 2.12"
     }
   }
 }


### PR DESCRIPTION
## Description
Supports `keep_remotely` `docker_registry_image` variable.
Fixes #283

## Motivation and Context
Workaround for problems described in #283 

## Breaking Changes
None, defaults to `false` as the provider has it set.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
