### PR TITLE
feat: Add support to build automatically npm dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,9 @@ source_path = [
 ]
 ```
 
-Few notes:
+*Few notes:*
 
+- If you specify a source path as a string that references a folder and the runtime is either python or nodejs, the build process will automatically build python and nodejs dependencies if `requirements.txt` or `package.json` file will be found in the source folder. If you want to customize this behavior, please use the object notation as explained below.
 - All arguments except `path` are optional.
 - `patterns` - List of Python regex filenames should satisfy. Default value is "include everything" which is equal to `patterns = [".*"]`. This can also be specified as multiline heredoc string (no comments allowed). Some examples of valid patterns:
 
@@ -447,10 +448,12 @@ Few notes:
     !abc/def/hgk/.*    # Filter out again in abc/def/hgk sub folder
 ```
 
-- `commands` - List of commands to run. If specified, this argument overrides `pip_requirements`.
+- `commands` - List of commands to run. If specified, this argument overrides `pip_requirements` and `npm_requirements`.
   - `:zip [source] [destination]` is a special command which creates content of current working directory (first argument) and places it inside of path (second argument).
 - `pip_requirements` - Controls whether to execute `pip install`. Set to `false` to disable this feature, `true` to run `pip install` with `requirements.txt` found in `path`. Or set to another filename which you want to use instead.
 - `pip_tmp_dir` - Set the base directory to make the temporary directory for pip installs. Can be useful for Docker in Docker builds.
+- `npm_requirements` - Controls whether to execute `npm install`. Set to `false` to disable this feature, `true` to run `npm install` with `package.json` found in `path`. Or set to another filename which you want to use instead.
+- `npm_tmp_dir` - Set the base directory to make the temporary directory for npm installs. Can be useful for Docker in Docker builds.
 - `prefix_in_zip` - If specified, will be used as a prefix inside zip-archive. By default, everything installs into the root of zip-archive.
 
 ### Building in Docker

--- a/README.md
+++ b/README.md
@@ -404,6 +404,11 @@ source_path = [
       "!vendor/colorful/__pycache__/?.*",
     ]
   }, {
+    path             = "src/nodejs14.x-app1",
+    npm_requirements = true,
+    nom_tmp_dir      = "/tmp/dir/location"
+    prefix_in_zip    = "foo/bar1",
+  }, {
     path     = "src/python3.8-app3",
     commands = [
       "npm install",

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ source_path = [
   }, {
     path             = "src/nodejs14.x-app1",
     npm_requirements = true,
-    nom_tmp_dir      = "/tmp/dir/location"
+    npm_tmp_dir      = "/tmp/dir/location"
     prefix_in_zip    = "foo/bar1",
   }, {
     path     = "src/python3.8-app3",

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ source_path = [
 
 *Few notes:*
 
-- If you specify a source path as a string that references a folder and the runtime is either python or nodejs, the build process will automatically build python and nodejs dependencies if `requirements.txt` or `package.json` file will be found in the source folder. If you want to customize this behavior, please use the object notation as explained below.
+- If you specify a source path as a string that references a folder and the runtime begins with `python` or `nodejs`, the build process will automatically build python and nodejs dependencies if `requirements.txt` or `package.json` file will be found in the source folder. If you want to customize this behavior, please use the object notation as explained below.
 - All arguments except `path` are optional.
 - `patterns` - List of Python regex filenames should satisfy. Default value is "include everything" which is equal to `patterns = [".*"]`. This can also be specified as multiline heredoc string (no comments allowed). Some examples of valid patterns:
 
@@ -463,7 +463,7 @@ If your Lambda Function or Layer uses some dependencies you can build them in Do
     build_in_docker   = true
     docker_file       = "src/python3.8-app1/docker/Dockerfile"
     docker_build_root = "src/python3.8-app1/docker"
-    docker_image      = "lambci/lambda:build-python3.8"
+    docker_image      = "public.ecr.aws/sam/build-python3.8"
     runtime           = "python3.8"    # Setting runtime is required when building package in Docker and Lambda Layer resource.
 
 Using this module you can install dependencies from private hosts. To do this, you need for forward SSH agent:

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -45,7 +45,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_file_with_pip_requirements"></a> [package\_file\_with\_pip\_requirements](#module\_package\_file\_with\_pip\_requirements) | ../../ | n/a |
 | <a name="module_package_with_commands_and_patterns"></a> [package\_with\_commands\_and\_patterns](#module\_package\_with\_commands\_and\_patterns) | ../../ | n/a |
 | <a name="module_package_with_docker"></a> [package\_with\_docker](#module\_package\_with\_docker) | ../../ | n/a |
-| <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in_docker](#module\_package\_with\_npm\_requirements\_in_docker) | ../../ | n/a |
+| <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in\_docker](#module\_package\_with\_npm\_requirements\_in\_docker) | ../../ | n/a |
 | <a name="module_package_with_patterns"></a> [package\_with\_patterns](#module\_package\_with\_patterns) | ../../ | n/a |
 | <a name="module_package_with_pip_requirements_in_docker"></a> [package\_with\_pip\_requirements\_in\_docker](#module\_package\_with\_pip\_requirements\_in\_docker) | ../../ | n/a |
 

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -45,6 +45,9 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_with_docker"></a> [package\_with\_docker](#module\_package\_with\_docker) | ../../ | n/a |
 | <a name="module_package_with_patterns"></a> [package\_with\_patterns](#module\_package\_with\_patterns) | ../../ | n/a |
 | <a name="module_package_with_pip_requirements_in_docker"></a> [package\_with\_pip\_requirements\_in\_docker](#module\_package\_with\_pip\_requirements\_in\_docker) | ../../ | n/a |
+| <a name="module_package_dir_with_npm_install"></a> [package\_dir\_with\_npm\_install](#module\_package\_dir\_with\_npm\_install) | ../../ | n/a |
+| <a name="module_package_dir_without_npm_install"></a> [package\_dir\_without\_npm\_install](#module\_package\_dir\_without\_npm\_install) | ../../ | n/a |
+| <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in_docker](#module\_package\_with\_npm\_requirements\_in_docker) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -38,16 +38,16 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_lambda_layer_pip_requirements"></a> [lambda\_layer\_pip\_requirements](#module\_lambda\_layer\_pip\_requirements) | ../.. | n/a |
 | <a name="module_package_dir"></a> [package\_dir](#module\_package\_dir) | ../../ | n/a |
 | <a name="module_package_dir_pip_dir"></a> [package\_dir\_pip\_dir](#module\_package\_dir\_pip\_dir) | ../../ | n/a |
+| <a name="module_package_dir_with_npm_install"></a> [package\_dir\_with\_npm\_install](#module\_package\_dir\_with\_npm\_install) | ../../ | n/a |
+| <a name="module_package_dir_without_npm_install"></a> [package\_dir\_without\_npm\_install](#module\_package\_dir\_without\_npm\_install) | ../../ | n/a |
 | <a name="module_package_dir_without_pip_install"></a> [package\_dir\_without\_pip\_install](#module\_package\_dir\_without\_pip\_install) | ../../ | n/a |
 | <a name="module_package_file"></a> [package\_file](#module\_package\_file) | ../../ | n/a |
 | <a name="module_package_file_with_pip_requirements"></a> [package\_file\_with\_pip\_requirements](#module\_package\_file\_with\_pip\_requirements) | ../../ | n/a |
 | <a name="module_package_with_commands_and_patterns"></a> [package\_with\_commands\_and\_patterns](#module\_package\_with\_commands\_and\_patterns) | ../../ | n/a |
 | <a name="module_package_with_docker"></a> [package\_with\_docker](#module\_package\_with\_docker) | ../../ | n/a |
+| <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in_docker](#module\_package\_with\_npm\_requirements\_in_docker) | ../../ | n/a |
 | <a name="module_package_with_patterns"></a> [package\_with\_patterns](#module\_package\_with\_patterns) | ../../ | n/a |
 | <a name="module_package_with_pip_requirements_in_docker"></a> [package\_with\_pip\_requirements\_in\_docker](#module\_package\_with\_pip\_requirements\_in\_docker) | ../../ | n/a |
-| <a name="module_package_dir_with_npm_install"></a> [package\_dir\_with\_npm\_install](#module\_package\_dir\_with\_npm\_install) | ../../ | n/a |
-| <a name="module_package_dir_without_npm_install"></a> [package\_dir\_without\_npm\_install](#module\_package\_dir\_without\_npm\_install) | ../../ | n/a |
-| <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in_docker](#module\_package\_with\_npm\_requirements\_in_docker) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -233,7 +233,7 @@ module "package_dir_with_npm_install" {
   source_path = "${path.module}/../fixtures/nodejs14.x-app1"
 }
 
-# Create zip-archive of a single directory without running "pip install" (which is default for python runtime)
+# Create zip-archive of a single directory without running "npm install" (which is the default for nodejs runtime)
 module "package_dir_without_npm_install" {
   source = "../../"
 

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -220,7 +220,7 @@ module "package_with_docker" {
   docker_with_ssh_agent = true
   #  docker_file           = "${path.module}/../fixtures/python3.8-app1/docker/Dockerfile"
   docker_build_root = "${path.module}/../../docker"
-  docker_image      = "lambci/lambda:build-python3.8"
+  docker_image      = "public.ecr.aws/sam/build-python3.8"
 }
 
 # Create zip-archive of a single directory where "npm install" will also be executed (default for nodejs runtime)
@@ -244,7 +244,7 @@ module "package_dir_without_npm_install" {
     {
       path             = "${path.module}/../fixtures/nodejs14.x-app1"
       npm_requirements = false
-      # npm_requirements = true  # Will run "npm install" with default requirements.txt
+      # npm_requirements = true  # Will run "npm install" with package.json
     }
   ]
 }
@@ -278,6 +278,7 @@ module "lambda_layer" {
 
   build_in_docker = true
   runtime         = "python3.8"
+  docker_image    = "public.ecr.aws/sam/build-python3.8"
   docker_file     = "${path.module}/../fixtures/python3.8-app1/docker/Dockerfile"
 }
 

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -223,6 +223,44 @@ module "package_with_docker" {
   docker_image      = "lambci/lambda:build-python3.8"
 }
 
+# Create zip-archive of a single directory where "npm install" will also be executed (default for nodejs runtime)
+module "package_dir_with_npm_install" {
+  source = "../../"
+
+  create_function = false
+
+  runtime     = "nodejs14.x"
+  source_path = "${path.module}/../fixtures/nodejs14.x-app1"
+}
+
+# Create zip-archive of a single directory without running "pip install" (which is default for python runtime)
+module "package_dir_without_npm_install" {
+  source = "../../"
+
+  create_function = false
+
+  runtime = "nodejs14.x"
+  source_path = [
+    {
+      path             = "${path.module}/../fixtures/nodejs14.x-app1"
+      npm_requirements = false
+      # npm_requirements = true  # Will run "npm install" with default requirements.txt
+    }
+  ]
+}
+
+# Create zip-archive of a single directory where "npm install" will also be executed using docker
+module "package_with_npm_requirements_in_docker" {
+  source = "../../"
+
+  create_function = false
+
+  runtime         = "nodejs14.x"
+  source_path     = "${path.module}/../fixtures/nodejs14.x-app1"
+  build_in_docker = true
+  hash_extra      = "something-unique-to-not-conflict-with-module.package_dir_with_npm_install"
+}
+
 ################################
 # Build package in Docker and
 # use it to deploy Lambda Layer

--- a/examples/fixtures/nodejs14.x-app1/index.js
+++ b/examples/fixtures/nodejs14.x-app1/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports.hello = async (event) => {
+  console.log(event);
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: `Go Serverless v3.0! Your Nodejs function executed successfully!`,
+        input: event,
+      },
+      null,
+      2
+    ),
+  };
+};

--- a/examples/fixtures/nodejs14.x-app1/index.js
+++ b/examples/fixtures/nodejs14.x-app1/index.js
@@ -6,7 +6,7 @@ module.exports.hello = async (event) => {
     statusCode: 200,
     body: JSON.stringify(
       {
-        message: `Go Serverless v3.0! Your Nodejs function executed successfully!`,
+        message: `Go Serverless.tf! Your Nodejs function executed successfully!`,
         input: event,
       },
       null,

--- a/examples/fixtures/nodejs14.x-app1/package.json
+++ b/examples/fixtures/nodejs14.x-app1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nodejs14.x-app1",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "requests": "^0.3.0"
+  }
+}

--- a/package.py
+++ b/package.py
@@ -660,6 +660,18 @@ class BuildPlanManager:
                 step('pip', runtime, requirements, prefix, tmp_dir)
                 hash(requirements)
 
+        def npm_requirements_step(path, prefix=None, required=False):
+            requirements = path
+            if os.path.isdir(path):
+                requirements = os.path.join(path, 'package.json')
+            if not os.path.isfile(requirements):
+                if required:
+                    raise RuntimeError(
+                        'File not found: {}'.format(requirements))
+            else:
+                step('npm', runtime, requirements, prefix, None)
+                hash(requirements)
+
         def commands_step(path, commands):
             if not commands:
                 return
@@ -717,6 +729,9 @@ class BuildPlanManager:
                 if runtime.startswith('python'):
                     pip_requirements_step(
                         os.path.join(path, 'requirements.txt'))
+                elif runtime.startswith('nodejs'):
+                    npm_requirements_step(
+                        os.path.join(path, 'package.json'))
                 step('zip', path, None)
                 hash(path)
 
@@ -731,6 +746,7 @@ class BuildPlanManager:
                 else:
                     prefix = claim.get('prefix_in_zip')
                     pip_requirements = claim.get('pip_requirements')
+                    npm_requirements = claim.get('npm_package_json')
                     runtime = claim.get('runtime', query.runtime)
 
                     if pip_requirements and runtime.startswith('python'):
@@ -739,6 +755,13 @@ class BuildPlanManager:
                         else:
                             pip_requirements_step(pip_requirements, prefix,
                                                   required=True, tmp_dir=claim.get('pip_tmp_dir'))
+
+                    if npm_requirements and runtime.startswith('nodejs'):
+                        if isinstance(npm_requirements, bool) and path:
+                            npm_requirements_step(path, prefix, required=True, tmp_dir=claim.get('npm_tmp_dir'))
+                        else:
+                            npm_requirements_step(npm_requirements, prefix,
+                                                  required=True, tmp_dir=claim.get('npm_tmp_dir'))
 
                     if path:
                         step('zip', path, prefix)
@@ -786,6 +809,16 @@ class BuildPlanManager:
             elif cmd == 'pip':
                 runtime, pip_requirements, prefix, tmp_dir = action[1:]
                 with install_pip_requirements(query, pip_requirements, tmp_dir) as rd:
+                    if rd:
+                        if pf:
+                            self._zip_write_with_filter(zs, pf, rd, prefix,
+                                                        timestamp=0)
+                        else:
+                            # XXX: timestamp=0 - what actually do with it?
+                            zs.write_dirs(rd, prefix=prefix, timestamp=0)
+            elif cmd == 'npm':
+                runtime, npm_requirements, prefix, tmp_dir = action[1:]
+                with install_npm_requirements(query, npm_requirements, tmp_dir) as rd:
                     if rd:
                         if pf:
                             self._zip_write_with_filter(zs, pf, rd, prefix,
@@ -934,6 +967,89 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
             yield temp_dir
 
 
+@contextmanager
+def install_npm_requirements(query, requirements_file, tmp_dir):
+    # TODO:
+    #  1. Emit files instead of temp_dir
+
+    if not os.path.exists(requirements_file):
+        yield
+        return
+
+    runtime = query.runtime
+    artifacts_dir = query.artifacts_dir
+    temp_dir = query.temp_dir
+    docker = query.docker
+    docker_image_tag_id = None
+
+    if docker:
+        docker_file = docker.docker_file
+        docker_image = docker.docker_image
+        docker_build_root = docker.docker_build_root
+
+        if docker_image:
+            ok = False
+            while True:
+                output = check_output(docker_image_id_command(docker_image))
+                if output:
+                    docker_image_tag_id = output.decode().strip()
+                    log.debug("DOCKER TAG ID: %s -> %s",
+                              docker_image, docker_image_tag_id)
+                    ok = True
+                if ok:
+                    break
+                docker_cmd = docker_build_command(
+                    build_root=docker_build_root,
+                    docker_file=docker_file,
+                    tag=docker_image,
+                )
+                check_call(docker_cmd)
+                ok = True
+        elif docker_file or docker_build_root:
+            raise ValueError('docker_image must be specified '
+                             'for a custom image future references')
+
+    log.info('Installing npm requirements: %s', requirements_file)
+    with tempdir(tmp_dir) as temp_dir:
+        requirements_filename = os.path.basename(requirements_file)
+        target_file = os.path.join(temp_dir, requirements_filename)
+        shutil.copyfile(requirements_file, target_file)
+
+        subproc_env = None
+        if not docker and OSX:
+            subproc_env = os.environ.copy()
+
+        # Install dependencies into the temporary directory.
+        with cd(temp_dir):
+            npm_command = ['npm', 'install']
+            if docker:
+                with_ssh_agent = docker.with_ssh_agent
+                chown_mask = '{}:{}'.format(os.getuid(), os.getgid())
+                shell_command = [shlex_join(npm_command), '&&',
+                                    shlex_join(['chown', '-R',
+                                                chown_mask, '.'])]
+                shell_command = [' '.join(shell_command)]
+                check_call(docker_run_command(
+                    '.', shell_command, runtime,
+                    image=docker_image_tag_id,
+                    shell=True, ssh_agent=with_ssh_agent
+                ))
+            else:
+                cmd_log.info(shlex_join(npm_command))
+                log_handler and log_handler.flush()
+                try:
+                    check_call(npm_command, env=subproc_env)
+                except FileNotFoundError as e:
+                    raise RuntimeError(
+                        "Nodejs interpreter version equal "
+                        "to defined lambda runtime ({}) should be "
+                        "available in system PATH".format(runtime)
+                    ) from e
+
+            os.remove(target_file)
+            yield temp_dir
+
+
 def docker_image_id_command(tag):
     """"""
     docker_cmd = ['docker', 'images', '--format={{.ID}}', tag]
@@ -1011,7 +1127,7 @@ def docker_run_command(build_root, command, runtime,
             ])
 
     if not image:
-        image = 'lambci/lambda:build-{}'.format(runtime)
+        image = 'public.ecr.aws/sam/build-{}'.format(runtime)
 
     docker_cmd.append(image)
 
@@ -1128,7 +1244,7 @@ def prepare_command(args):
 def build_command(args):
     """
     Builds a zip file from the source_dir or source_file.
-    Installs dependencies with pip automatically.
+    Installs dependencies with pip or npm automatically.
     """
 
     log = logging.getLogger('build')

--- a/package.py
+++ b/package.py
@@ -660,7 +660,7 @@ class BuildPlanManager:
                 step('pip', runtime, requirements, prefix, tmp_dir)
                 hash(requirements)
 
-        def npm_requirements_step(path, prefix=None, required=False):
+        def npm_requirements_step(path, prefix=None, required=False, tmp_dir=None):
             requirements = path
             if os.path.isdir(path):
                 requirements = os.path.join(path, 'package.json')
@@ -669,7 +669,7 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
-                step('npm', runtime, requirements, prefix, None)
+                step('npm', runtime, requirements, prefix, tmp_dir)
                 hash(requirements)
 
         def commands_step(path, commands):


### PR DESCRIPTION
Fully based on #292 where I didn't have permission to push changes. Fixes #292.

1. Add support to build automatically npm dependencies, with docker support. 
2. Change default docker image from lambci to official AWS SAM images

## Description
As made for pip requirements, this PR adds support to build Nodejs dependencies automatically with or without docker.

## Motivation and Context
This PR simplifies the process needed to build and deploy Nodejs functions and, thanks to docker, allows users to build functions without the need to have the interpreter installed locally
 
## Breaking Changes
No breaking changes introduced

## How Has This Been Tested?
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ x ] I have also tested the real deployment of Python and Nodejs functions with and without dependencies.