### PR TITLE
feat!: Updated AWS provider to version 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.37.0](https://github.com/terraform-aws-modules/terraform-aws-lambda/compare/v2.36.0...v2.37.0) (2022-03-26)
+
+
+### Features
+
+* Added support for ephemeral storage (requires AWS provider version 4.8.0) ([#291](https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/291)) ([f191bae](https://github.com/terraform-aws-modules/terraform-aws-lambda/commit/f191baea053e126fc6b83a2ea4d6988c4f47ebde))
+
 ## [2.36.0](https://github.com/terraform-aws-modules/terraform-aws-lambda/compare/v2.35.1...v2.36.0) (2022-03-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.37.0](https://github.com/terraform-aws-modules/terraform-aws-lambda/compare/v2.36.0...v2.37.0) (2022-03-26)
-
-
-### Features
-
-* Added support for ephemeral storage (requires AWS provider version 4.8.0) ([#291](https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/291)) ([f191bae](https://github.com/terraform-aws-modules/terraform-aws-lambda/commit/f191baea053e126fc6b83a2ea4d6988c4f47ebde))
-
 ## [2.36.0](https://github.com/terraform-aws-modules/terraform-aws-lambda/compare/v2.35.1...v2.36.0) (2022-03-26)
 
 

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
@@ -611,7 +611,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.8 |
 | <a name="provider_external"></a> [external](#provider\_external) | >= 1.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
@@ -710,7 +710,7 @@ No modules.
 | <a name="input_docker_pip_cache"></a> [docker\_pip\_cache](#input\_docker\_pip\_cache) | Whether to mount a shared pip cache folder into docker environment or not | `any` | `null` | no |
 | <a name="input_docker_with_ssh_agent"></a> [docker\_with\_ssh\_agent](#input\_docker\_with\_ssh\_agent) | Whether to pass SSH\_AUTH\_SOCK into docker environment or not | `bool` | `false` | no |
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | A map that defines environment variables for the Lambda Function. | `map(string)` | `{}` | no |
-| <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | Amount of ephemeral storage size (`/tmp`) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
+| <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
 | <a name="input_event_source_mapping"></a> [event\_source\_mapping](#input\_event\_source\_mapping) | Map of event source mapping | `any` | `{}` | no |
 | <a name="input_file_system_arn"></a> [file\_system\_arn](#input\_file\_system\_arn) | The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system. | `string` | `null` | no |
 | <a name="input_file_system_local_mount_path"></a> [file\_system\_local\_mount\_path](#input\_file\_system\_local\_mount\_path) | The path where the function can access the file system, starting with /mnt/. | `string` | `null` | no |

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -21,13 +21,13 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.61 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.61 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.61"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.61"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -21,13 +21,13 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,15 +21,15 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.67 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.8 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.67 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.8 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 4.8.0"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.8"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -21,13 +21,13 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
@@ -30,7 +30,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
 | <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 3.19 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -21,13 +21,13 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -22,14 +22,14 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.67 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.67 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/triggers/versions.tf
+++ b/examples/triggers/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 2.67"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.67"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -22,14 +22,14 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.19 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/with-efs/versions.tf
+++ b/examples/with-efs/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -23,13 +23,13 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.19 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 

--- a/examples/with-vpc/versions.tf
+++ b/examples/with-vpc/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.19"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.19"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -57,13 +57,13 @@ data "aws_iam_policy_document" "assume_role" {
     for_each = var.assume_role_policy_statements
 
     content {
-      sid         = lookup(statement.value, "sid", replace(statement.key, "/[^0-9A-Za-z]*/", ""))
-      effect      = lookup(statement.value, "effect", null)
-      actions     = lookup(statement.value, "actions", null)
-      not_actions = lookup(statement.value, "not_actions", null)
+      sid         = try(statement.value.sid, replace(statement.key, "/[^0-9A-Za-z]*/", ""))
+      effect      = try(statement.value.effect, null)
+      actions     = try(statement.value.actions, null)
+      not_actions = try(statement.value.not_actions, null)
 
       dynamic "principals" {
-        for_each = lookup(statement.value, "principals", [])
+        for_each = try(statement.value.principals, [])
         content {
           type        = principals.value.type
           identifiers = principals.value.identifiers
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "assume_role" {
       }
 
       dynamic "not_principals" {
-        for_each = lookup(statement.value, "not_principals", [])
+        for_each = try(statement.value.not_principals, [])
         content {
           type        = not_principals.value.type
           identifiers = not_principals.value.identifiers
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "assume_role" {
       }
 
       dynamic "condition" {
-        for_each = lookup(statement.value, "condition", [])
+        for_each = try(statement.value.condition, [])
         content {
           test     = condition.value.test
           variable = condition.value.variable
@@ -346,15 +346,15 @@ data "aws_iam_policy_document" "additional_inline" {
     for_each = var.policy_statements
 
     content {
-      sid           = lookup(statement.value, "sid", replace(statement.key, "/[^0-9A-Za-z]*/", ""))
-      effect        = lookup(statement.value, "effect", null)
-      actions       = lookup(statement.value, "actions", null)
-      not_actions   = lookup(statement.value, "not_actions", null)
-      resources     = lookup(statement.value, "resources", null)
-      not_resources = lookup(statement.value, "not_resources", null)
+      sid           = try(statement.value.sid, replace(statement.key, "/[^0-9A-Za-z]*/", ""))
+      effect        = try(statement.value.effect, null)
+      actions       = try(statement.value.actions, null)
+      not_actions   = try(statement.value.not_actions, null)
+      resources     = try(statement.value.resources, null)
+      not_resources = try(statement.value.not_resources, null)
 
       dynamic "principals" {
-        for_each = lookup(statement.value, "principals", [])
+        for_each = try(statement.value.principals, [])
         content {
           type        = principals.value.type
           identifiers = principals.value.identifiers
@@ -362,7 +362,7 @@ data "aws_iam_policy_document" "additional_inline" {
       }
 
       dynamic "not_principals" {
-        for_each = lookup(statement.value, "not_principals", [])
+        for_each = try(statement.value.not_principals, [])
         content {
           type        = not_principals.value.type
           identifiers = not_principals.value.identifiers
@@ -370,7 +370,7 @@ data "aws_iam_policy_document" "additional_inline" {
       }
 
       dynamic "condition" {
-        for_each = lookup(statement.value, "condition", [])
+        for_each = try(statement.value.condition, [])
         content {
           test     = condition.value.test
           variable = condition.value.variable

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,9 @@ locals {
   was_missing = var.local_existing_package != null ? !fileexists(var.local_existing_package) : local.archive_was_missing
 
   # s3_* - to get package from S3
-  s3_bucket         = var.s3_existing_package != null ? lookup(var.s3_existing_package, "bucket", null) : (var.store_on_s3 ? var.s3_bucket : null)
-  s3_key            = var.s3_existing_package != null ? lookup(var.s3_existing_package, "key", null) : (var.store_on_s3 ? var.s3_prefix != null ? format("%s%s", var.s3_prefix, replace(local.archive_filename_string, "/^.*//", "")) : replace(local.archive_filename_string, "/^\\.//", "") : null)
-  s3_object_version = var.s3_existing_package != null ? lookup(var.s3_existing_package, "version_id", null) : (var.store_on_s3 ? try(aws_s3_object.lambda_package[0].version_id, null) : null)
+  s3_bucket         = var.s3_existing_package != null ? try(var.s3_existing_package.bucket, null) : (var.store_on_s3 ? var.s3_bucket : null)
+  s3_key            = var.s3_existing_package != null ? try(var.s3_existing_package.key, null) : (var.store_on_s3 ? var.s3_prefix != null ? format("%s%s", var.s3_prefix, replace(local.archive_filename_string, "/^.*//", "")) : replace(local.archive_filename_string, "/^\\.//", "") : null)
+  s3_object_version = var.s3_existing_package != null ? try(var.s3_existing_package.version_id, null) : (var.store_on_s3 ? try(aws_s3_object.lambda_package[0].version_id, null) : null)
 
 }
 
@@ -204,12 +204,12 @@ resource "aws_lambda_permission" "current_version_triggers" {
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
 
-  statement_id       = lookup(each.value, "statement_id", each.key)
-  action             = lookup(each.value, "action", "lambda:InvokeFunction")
-  principal          = lookup(each.value, "principal", format("%s.amazonaws.com", lookup(each.value, "service", "")))
-  source_arn         = lookup(each.value, "source_arn", null)
-  source_account     = lookup(each.value, "source_account", null)
-  event_source_token = lookup(each.value, "event_source_token", null)
+  statement_id       = try(each.value.statement_id, each.key)
+  action             = try(each.value.action, "lambda:InvokeFunction")
+  principal          = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  source_arn         = try(each.value.source_arn, null)
+  source_account     = try(each.value.source_account, null)
+  event_source_token = try(each.value.event_source_token, null)
 }
 
 # Error: Error adding new Lambda Permission for lambda: InvalidParameterValueException: We currently do not support adding policies for $LATEST.
@@ -218,12 +218,12 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 
   function_name = aws_lambda_function.this[0].function_name
 
-  statement_id       = lookup(each.value, "statement_id", each.key)
-  action             = lookup(each.value, "action", "lambda:InvokeFunction")
-  principal          = lookup(each.value, "principal", format("%s.amazonaws.com", lookup(each.value, "service", "")))
-  source_arn         = lookup(each.value, "source_arn", null)
-  source_account     = lookup(each.value, "source_account", null)
-  event_source_token = lookup(each.value, "event_source_token", null)
+  statement_id       = try(each.value.statement_id, each.key)
+  action             = try(each.value.action, "lambda:InvokeFunction")
+  principal          = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  source_arn         = try(each.value.source_arn, null)
+  source_account     = try(each.value.source_account, null)
+  event_source_token = try(each.value.event_source_token, null)
 }
 
 resource "aws_lambda_event_source_mapping" "this" {
@@ -233,21 +233,21 @@ resource "aws_lambda_event_source_mapping" "this" {
 
   event_source_arn = each.value.event_source_arn
 
-  batch_size                         = lookup(each.value, "batch_size", null)
-  maximum_batching_window_in_seconds = lookup(each.value, "maximum_batching_window_in_seconds", null)
-  enabled                            = lookup(each.value, "enabled", null)
-  starting_position                  = lookup(each.value, "starting_position", null)
-  starting_position_timestamp        = lookup(each.value, "starting_position_timestamp", null)
-  parallelization_factor             = lookup(each.value, "parallelization_factor", null)
-  maximum_retry_attempts             = lookup(each.value, "maximum_retry_attempts", null)
-  maximum_record_age_in_seconds      = lookup(each.value, "maximum_record_age_in_seconds", null)
-  bisect_batch_on_function_error     = lookup(each.value, "bisect_batch_on_function_error", null)
-  topics                             = lookup(each.value, "topics", null)
-  queues                             = lookup(each.value, "queues", null)
-  function_response_types            = lookup(each.value, "function_response_types", null)
+  batch_size                         = try(each.value.batch_size, null)
+  maximum_batching_window_in_seconds = try(each.value.maximum_batching_window_in_seconds, null)
+  enabled                            = try(each.value.enabled, null)
+  starting_position                  = try(each.value.starting_position, null)
+  starting_position_timestamp        = try(each.value.starting_position_timestamp, null)
+  parallelization_factor             = try(each.value.parallelization_factor, null)
+  maximum_retry_attempts             = try(each.value.maximum_retry_attempts, null)
+  maximum_record_age_in_seconds      = try(each.value.maximum_record_age_in_seconds, null)
+  bisect_batch_on_function_error     = try(each.value.bisect_batch_on_function_error, null)
+  topics                             = try(each.value.topics, null)
+  queues                             = try(each.value.queues, null)
+  function_response_types            = try(each.value.function_response_types, null)
 
   dynamic "destination_config" {
-    for_each = lookup(each.value, "destination_arn_on_failure", null) != null ? [true] : []
+    for_each = try(each.value.destination_arn_on_failure, null) != null ? [true] : []
     content {
       on_failure {
         destination_arn = each.value["destination_arn_on_failure"]
@@ -256,7 +256,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   }
 
   dynamic "source_access_configuration" {
-    for_each = lookup(each.value, "source_access_configuration", [])
+    for_each = try(each.value.source_access_configuration, [])
     content {
       type = source_access_configuration.value["type"]
       uri  = source_access_configuration.value["uri"]
@@ -264,11 +264,11 @@ resource "aws_lambda_event_source_mapping" "this" {
   }
 
   dynamic "filter_criteria" {
-    for_each = lookup(each.value, "filter_criteria", null) != null ? [true] : []
+    for_each = try(each.value.filter_criteria, null) != null ? [true] : []
 
     content {
       filter {
-        pattern = lookup(each.value["filter_criteria"], "pattern", null)
+        pattern = try(each.value["filter_criteria"].pattern, null)
       }
     }
   }

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -87,12 +87,12 @@ resource "aws_lambda_permission" "version_triggers" {
   # Error: Error adding new Lambda Permission for ... InvalidParameterValueException: We currently do not support adding policies for $LATEST.
   qualifier = local.version != "$LATEST" ? local.version : null
 
-  statement_id       = lookup(each.value, "statement_id", each.key)
-  action             = lookup(each.value, "action", "lambda:InvokeFunction")
-  principal          = lookup(each.value, "principal", format("%s.amazonaws.com", lookup(each.value, "service", "")))
-  source_arn         = lookup(each.value, "source_arn", null)
-  source_account     = lookup(each.value, "source_account", null)
-  event_source_token = lookup(each.value, "event_source_token", null)
+  statement_id       = try(each.value.statement_id, each.key)
+  action             = try(each.value.action, "lambda:InvokeFunction")
+  principal          = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  source_arn         = try(each.value.source_arn, null)
+  source_account     = try(each.value.source_account, null)
+  event_source_token = try(each.value.event_source_token, null)
 }
 
 resource "aws_lambda_permission" "qualified_alias_triggers" {
@@ -101,10 +101,10 @@ resource "aws_lambda_permission" "qualified_alias_triggers" {
   function_name = var.function_name
   qualifier     = var.name
 
-  statement_id       = lookup(each.value, "statement_id", each.key)
-  action             = lookup(each.value, "action", "lambda:InvokeFunction")
-  principal          = lookup(each.value, "principal", format("%s.amazonaws.com", lookup(each.value, "service", "")))
-  source_arn         = lookup(each.value, "source_arn", null)
-  source_account     = lookup(each.value, "source_account", null)
-  event_source_token = lookup(each.value, "event_source_token", null)
+  statement_id       = try(each.value.statement_id, each.key)
+  action             = try(each.value.action, "lambda:InvokeFunction")
+  principal          = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  source_arn         = try(each.value.source_arn, null)
+  source_account     = try(each.value.source_account, null)
+  event_source_token = try(each.value.event_source_token, null)
 }

--- a/modules/alias/versions.tf
+++ b/modules/alias/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.35"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.35"
+    }
   }
 }

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -102,16 +102,16 @@ module "lambda" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 2 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 1.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules
 

--- a/modules/deploy/versions.tf
+++ b/modules/deploy/versions.tf
@@ -2,8 +2,17 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws   = ">= 3.35"
-    local = ">= 1"
-    null  = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.35"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.8.0"
+      version = ">= 4.8"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
This is the correction after https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/291

## Description

* Added support for ephemeral storage (requires AWS provider version 4.8.0)

## Breaking Changes
Yes