### PR TITLE
Updated tags for aws_ecr_repository

### DIFF
--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -41,7 +41,7 @@ resource "aws_ecr_repository" "this" {
     scan_on_push = var.scan_on_push
   }
 
-  tags = var.ecr_repo_tags
+  tags = var.tags
 }
 
 resource "aws_ecr_lifecycle_policy" "this" {

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -70,3 +70,9 @@ variable "keep_remotely" {
   type        = bool
   default     = false
 }
+
+variable "tags" {
+  description = "A map of tags to assign to ECR repository"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description
Updated tags variable for the aws_ecr_repository repo as below.

Resource (In the 'terraform-aws-lambda -> modules -> docker-build -> main.tf' file): "aws_ecr_repository"
Resource name: "this"


## Motivation and Context
When we began using the repo, we found that one of the resources is yet to be tag enabled in the standard way. Hence when our internal projects were calling this repo, our custom tags were not being added in AWS.

## Breaking Changes
None

## How Has This Been Tested?
This is a basic feature to add tags with no functional change introduced . It has been done as per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository
