### PR TITLE
fix: Override docker entrypoint when it exists

### DIFF
--- a/package.py
+++ b/package.py
@@ -1129,6 +1129,8 @@ def docker_run_command(build_root, command, runtime,
     if not image:
         image = 'public.ecr.aws/sam/build-{}'.format(runtime)
 
+    docker_cmd.extend(['--entrypoint', ''])
+
     docker_cmd.append(image)
 
     assert isinstance(command, list)


### PR DESCRIPTION
Fixes #313 

## Description
When a base image contains an entrypoint path, it'll cause an `entrypoint requires the handler name to be the first argument` error to be thrown as the current run commend doesn't override it.

## Motivation and Context
See issue #313. I am not sure when it happened, but the official AWS lambda runtime images started including entrypoints (lambci images still do not).

## Breaking Changes
Nope

## How Has This Been Tested?
Tested and working on my personal project. Official tests still todo:
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
