### PR TITLE
feat: Added support for event source mapping in alias submodule

### DIFF
--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -35,11 +35,9 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_alias_existing"></a> [alias\_existing](#module\_alias\_existing) | ../../modules/alias | n/a |
 | <a name="module_alias_no_refresh"></a> [alias\_no\_refresh](#module\_alias\_no\_refresh) | ../../modules/alias | n/a |
-| <a name="module_alias_no_refresh_event_mapping"></a> [alias\_no\_refresh\_event\_mapping](#module\_alias\_no\_refresh\_event\_mapping) | ../../modules/alias | n/a |
 | <a name="module_alias_refresh"></a> [alias\_refresh](#module\_alias\_refresh) | ../../modules/alias | n/a |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ | n/a |
-| <a name="module_lambda_function_event_mapping"></a> [lambda\_function\_event\_mapping](#module\_lambda\_function\_event\_mapping) | ../../ | n/a |
-| <a name="module_sqs_events"></a> [sqs\_events](#module\_sqs\_events) | terraform-aws-modules/sqs/aws | v3.3.0 |
+| <a name="module_sqs_events"></a> [sqs\_events](#module\_sqs\_events) | terraform-aws-modules/sqs/aws | ~> 3.0 |
 
 ## Resources
 

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -35,8 +35,11 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_alias_existing"></a> [alias\_existing](#module\_alias\_existing) | ../../modules/alias | n/a |
 | <a name="module_alias_no_refresh"></a> [alias\_no\_refresh](#module\_alias\_no\_refresh) | ../../modules/alias | n/a |
+| <a name="module_alias_no_refresh_event_mapping"></a> [alias\_no\_refresh\_event\_mapping](#module\_alias\_no\_refresh\_event\_mapping) | ../../modules/alias | n/a |
 | <a name="module_alias_refresh"></a> [alias\_refresh](#module\_alias\_refresh) | ../../modules/alias | n/a |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | ../../ | n/a |
+| <a name="module_lambda_function_event_mapping"></a> [lambda\_function\_event\_mapping](#module\_lambda\_function\_event\_mapping) | ../../ | n/a |
+| <a name="module_sqs_events"></a> [sqs\_events](#module\_sqs\_events) | terraform-aws-modules/sqs/aws | v3.3.0 |
 
 ## Resources
 
@@ -54,6 +57,10 @@ No inputs.
 |------|-------------|
 | <a name="output_lambda_alias_arn"></a> [lambda\_alias\_arn](#output\_lambda\_alias\_arn) | The ARN of the Lambda Function Alias |
 | <a name="output_lambda_alias_description"></a> [lambda\_alias\_description](#output\_lambda\_alias\_description) | Description of alias |
+| <a name="output_lambda_alias_event_source_mapping_function_arn"></a> [lambda\_alias\_event\_source\_mapping\_function\_arn](#output\_lambda\_alias\_event\_source\_mapping\_function\_arn) | The the ARN of the Lambda function the event source mapping is sending events to |
+| <a name="output_lambda_alias_event_source_mapping_state"></a> [lambda\_alias\_event\_source\_mapping\_state](#output\_lambda\_alias\_event\_source\_mapping\_state) | The state of the event source mapping |
+| <a name="output_lambda_alias_event_source_mapping_state_transition_reason"></a> [lambda\_alias\_event\_source\_mapping\_state\_transition\_reason](#output\_lambda\_alias\_event\_source\_mapping\_state\_transition\_reason) | The reason the event source mapping is in its current state |
+| <a name="output_lambda_alias_event_source_mapping_uuid"></a> [lambda\_alias\_event\_source\_mapping\_uuid](#output\_lambda\_alias\_event\_source\_mapping\_uuid) | The UUID of the created event source mapping |
 | <a name="output_lambda_alias_function_version"></a> [lambda\_alias\_function\_version](#output\_lambda\_alias\_function\_version) | Lambda function version which the alias uses |
 | <a name="output_lambda_alias_invoke_arn"></a> [lambda\_alias\_invoke\_arn](#output\_lambda\_alias\_invoke\_arn) | The ARN to be used for invoking Lambda Function from API Gateway |
 | <a name="output_lambda_alias_name"></a> [lambda\_alias\_name](#output\_lambda\_alias\_name) | The name of the Lambda Function Alias |

--- a/examples/alias/main.tf
+++ b/examples/alias/main.tf
@@ -27,7 +27,7 @@ module "lambda_function" {
   create_async_event_config    = true
   maximum_event_age_in_seconds = 100
 
-  provisioned_concurrent_executions = -1
+  provisioned_concurrent_executions = 1
 
   allowed_triggers = {
     APIGatewayAny = {

--- a/examples/alias/outputs.tf
+++ b/examples/alias/outputs.tf
@@ -119,3 +119,23 @@ output "lambda_alias_function_version" {
   description = "Lambda function version which the alias uses"
   value       = module.alias_refresh.lambda_alias_function_version
 }
+
+output "lambda_alias_event_source_mapping_function_arn" {
+  description = "The the ARN of the Lambda function the event source mapping is sending events to"
+  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_function_arn
+}
+
+output "lambda_alias_event_source_mapping_state" {
+  description = "The state of the event source mapping"
+  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_state
+}
+
+output "lambda_alias_event_source_mapping_state_transition_reason" {
+  description = "The reason the event source mapping is in its current state"
+  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_state_transition_reason
+}
+
+output "lambda_alias_event_source_mapping_uuid" {
+  description = "The UUID of the created event source mapping"
+  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_uuid
+}

--- a/examples/alias/outputs.tf
+++ b/examples/alias/outputs.tf
@@ -122,20 +122,20 @@ output "lambda_alias_function_version" {
 
 output "lambda_alias_event_source_mapping_function_arn" {
   description = "The the ARN of the Lambda function the event source mapping is sending events to"
-  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_function_arn
+  value       = module.alias_no_refresh.lambda_alias_event_source_mapping_function_arn
 }
 
 output "lambda_alias_event_source_mapping_state" {
   description = "The state of the event source mapping"
-  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_state
+  value       = module.alias_no_refresh.lambda_alias_event_source_mapping_state
 }
 
 output "lambda_alias_event_source_mapping_state_transition_reason" {
   description = "The reason the event source mapping is in its current state"
-  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_state_transition_reason
+  value       = module.alias_no_refresh.lambda_alias_event_source_mapping_state_transition_reason
 }
 
 output "lambda_alias_event_source_mapping_uuid" {
   description = "The UUID of the created event source mapping"
-  value       = module.alias_no_refresh_event_mapping.lambda_alias_event_source_mapping_uuid
+  value       = module.alias_no_refresh.lambda_alias_event_source_mapping_uuid
 }

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -134,8 +134,7 @@ No modules.
 |------|------|
 | [aws_lambda_alias.no_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
 | [aws_lambda_alias.with_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
-| [aws_lambda_event_source_mapping.no_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
-| [aws_lambda_event_source_mapping.with_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_permission.qualified_alias_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.version_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -134,6 +134,8 @@ No modules.
 |------|------|
 | [aws_lambda_alias.no_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
 | [aws_lambda_alias.with_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
+| [aws_lambda_event_source_mapping.no_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_lambda_event_source_mapping.with_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_permission.qualified_alias_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.version_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
@@ -153,6 +155,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description of the alias. | `string` | `""` | no |
 | <a name="input_destination_on_failure"></a> [destination\_on\_failure](#input\_destination\_on\_failure) | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
 | <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
+| <a name="input_event_source_mapping"></a> [event\_source\_mapping](#input\_event\_source\_mapping) | Map of event source mapping | `any` | `{}` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The function ARN of the Lambda function for which you want to create an alias. | `string` | `""` | no |
 | <a name="input_function_version"></a> [function\_version](#input\_function\_version) | Lambda function version for which you are creating the alias. Pattern: ($LATEST\|[0-9]+). | `string` | `""` | no |
 | <a name="input_maximum_event_age_in_seconds"></a> [maximum\_event\_age\_in\_seconds](#input\_maximum\_event\_age\_in\_seconds) | Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600. | `number` | `null` | no |
@@ -168,6 +171,10 @@ No modules.
 |------|-------------|
 | <a name="output_lambda_alias_arn"></a> [lambda\_alias\_arn](#output\_lambda\_alias\_arn) | The ARN of the Lambda Function Alias |
 | <a name="output_lambda_alias_description"></a> [lambda\_alias\_description](#output\_lambda\_alias\_description) | Description of alias |
+| <a name="output_lambda_alias_event_source_mapping_function_arn"></a> [lambda\_alias\_event\_source\_mapping\_function\_arn](#output\_lambda\_alias\_event\_source\_mapping\_function\_arn) | The the ARN of the Lambda function the event source mapping is sending events to |
+| <a name="output_lambda_alias_event_source_mapping_state"></a> [lambda\_alias\_event\_source\_mapping\_state](#output\_lambda\_alias\_event\_source\_mapping\_state) | The state of the event source mapping |
+| <a name="output_lambda_alias_event_source_mapping_state_transition_reason"></a> [lambda\_alias\_event\_source\_mapping\_state\_transition\_reason](#output\_lambda\_alias\_event\_source\_mapping\_state\_transition\_reason) | The reason the event source mapping is in its current state |
+| <a name="output_lambda_alias_event_source_mapping_uuid"></a> [lambda\_alias\_event\_source\_mapping\_uuid](#output\_lambda\_alias\_event\_source\_mapping\_uuid) | The UUID of the created event source mapping |
 | <a name="output_lambda_alias_function_version"></a> [lambda\_alias\_function\_version](#output\_lambda\_alias\_function\_version) | Lambda function version which the alias uses |
 | <a name="output_lambda_alias_invoke_arn"></a> [lambda\_alias\_invoke\_arn](#output\_lambda\_alias\_invoke\_arn) | The ARN to be used for invoking Lambda Function from API Gateway |
 | <a name="output_lambda_alias_name"></a> [lambda\_alias\_name](#output\_lambda\_alias\_name) | The name of the Lambda Function Alias |

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -108,3 +108,113 @@ resource "aws_lambda_permission" "qualified_alias_triggers" {
   source_account     = try(each.value.source_account, null)
   event_source_token = try(each.value.event_source_token, null)
 }
+
+resource "aws_lambda_event_source_mapping" "no_refresh" {
+  for_each = { for k, v in var.event_source_mapping : k => v if var.create && !var.use_existing_alias && !var.refresh_alias }
+
+  function_name = aws_lambda_alias.no_refresh[0].arn
+
+  event_source_arn = try(each.value.event_source_arn, null)
+
+  batch_size                         = try(each.value.batch_size, null)
+  maximum_batching_window_in_seconds = try(each.value.maximum_batching_window_in_seconds, null)
+  enabled                            = try(each.value.enabled, null)
+  starting_position                  = try(each.value.starting_position, null)
+  starting_position_timestamp        = try(each.value.starting_position_timestamp, null)
+  parallelization_factor             = try(each.value.parallelization_factor, null)
+  maximum_retry_attempts             = try(each.value.maximum_retry_attempts, null)
+  maximum_record_age_in_seconds      = try(each.value.maximum_record_age_in_seconds, null)
+  bisect_batch_on_function_error     = try(each.value.bisect_batch_on_function_error, null)
+  topics                             = try(each.value.topics, null)
+  queues                             = try(each.value.queues, null)
+  function_response_types            = try(each.value.function_response_types, null)
+
+  dynamic "destination_config" {
+    for_each = try(each.value.destination_arn_on_failure, null) != null ? [true] : []
+    content {
+      on_failure {
+        destination_arn = each.value["destination_arn_on_failure"]
+      }
+    }
+  }
+
+  dynamic "self_managed_event_source" {
+    for_each = try(each.value.self_managed_event_source, [])
+    content {
+      endpoints = self_managed_event_source.value.endpoints
+    }
+  }
+
+  dynamic "source_access_configuration" {
+    for_each = try(each.value.source_access_configuration, [])
+    content {
+      type = source_access_configuration.value["type"]
+      uri  = source_access_configuration.value["uri"]
+    }
+  }
+
+  dynamic "filter_criteria" {
+    for_each = try(each.value.filter_criteria, null) != null ? [true] : []
+
+    content {
+      filter {
+        pattern = try(each.value["filter_criteria"].pattern, null)
+      }
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "with_refresh" {
+  for_each = { for k, v in var.event_source_mapping : k => v if var.create && !var.use_existing_alias && var.refresh_alias }
+
+  function_name = aws_lambda_alias.with_refresh[0].arn
+
+  event_source_arn = try(each.value.event_source_arn, null)
+
+  batch_size                         = try(each.value.batch_size, null)
+  maximum_batching_window_in_seconds = try(each.value.maximum_batching_window_in_seconds, null)
+  enabled                            = try(each.value.enabled, null)
+  starting_position                  = try(each.value.starting_position, null)
+  starting_position_timestamp        = try(each.value.starting_position_timestamp, null)
+  parallelization_factor             = try(each.value.parallelization_factor, null)
+  maximum_retry_attempts             = try(each.value.maximum_retry_attempts, null)
+  maximum_record_age_in_seconds      = try(each.value.maximum_record_age_in_seconds, null)
+  bisect_batch_on_function_error     = try(each.value.bisect_batch_on_function_error, null)
+  topics                             = try(each.value.topics, null)
+  queues                             = try(each.value.queues, null)
+  function_response_types            = try(each.value.function_response_types, null)
+
+  dynamic "destination_config" {
+    for_each = try(each.value.destination_arn_on_failure, null) != null ? [true] : []
+    content {
+      on_failure {
+        destination_arn = each.value["destination_arn_on_failure"]
+      }
+    }
+  }
+
+  dynamic "self_managed_event_source" {
+    for_each = try(each.value.self_managed_event_source, [])
+    content {
+      endpoints = self_managed_event_source.value.endpoints
+    }
+  }
+
+  dynamic "source_access_configuration" {
+    for_each = try(each.value.source_access_configuration, [])
+    content {
+      type = source_access_configuration.value["type"]
+      uri  = source_access_configuration.value["uri"]
+    }
+  }
+
+  dynamic "filter_criteria" {
+    for_each = try(each.value.filter_criteria, null) != null ? [true] : []
+
+    content {
+      filter {
+        pattern = try(each.value["filter_criteria"].pattern, null)
+      }
+    }
+  }
+}

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -1,4 +1,5 @@
 locals {
+  alias_arn  = try(data.aws_lambda_alias.existing[0].arn, aws_lambda_alias.no_refresh[0].arn, aws_lambda_alias.with_refresh[0].arn, "")
   version    = try(data.aws_lambda_alias.existing[0].function_version, aws_lambda_alias.with_refresh[0].function_version, aws_lambda_alias.no_refresh[0].function_version, "")
   qualifiers = zipmap(["version", "qualified_alias"], [var.create_version_async_event_config ? true : null, var.create_qualified_alias_async_event_config ? true : null])
 }
@@ -109,65 +110,10 @@ resource "aws_lambda_permission" "qualified_alias_triggers" {
   event_source_token = try(each.value.event_source_token, null)
 }
 
-resource "aws_lambda_event_source_mapping" "no_refresh" {
-  for_each = { for k, v in var.event_source_mapping : k => v if var.create && !var.use_existing_alias && !var.refresh_alias }
+resource "aws_lambda_event_source_mapping" "this" {
+  for_each = { for k, v in var.event_source_mapping : k => v if var.create }
 
-  function_name = aws_lambda_alias.no_refresh[0].arn
-
-  event_source_arn = try(each.value.event_source_arn, null)
-
-  batch_size                         = try(each.value.batch_size, null)
-  maximum_batching_window_in_seconds = try(each.value.maximum_batching_window_in_seconds, null)
-  enabled                            = try(each.value.enabled, null)
-  starting_position                  = try(each.value.starting_position, null)
-  starting_position_timestamp        = try(each.value.starting_position_timestamp, null)
-  parallelization_factor             = try(each.value.parallelization_factor, null)
-  maximum_retry_attempts             = try(each.value.maximum_retry_attempts, null)
-  maximum_record_age_in_seconds      = try(each.value.maximum_record_age_in_seconds, null)
-  bisect_batch_on_function_error     = try(each.value.bisect_batch_on_function_error, null)
-  topics                             = try(each.value.topics, null)
-  queues                             = try(each.value.queues, null)
-  function_response_types            = try(each.value.function_response_types, null)
-
-  dynamic "destination_config" {
-    for_each = try(each.value.destination_arn_on_failure, null) != null ? [true] : []
-    content {
-      on_failure {
-        destination_arn = each.value["destination_arn_on_failure"]
-      }
-    }
-  }
-
-  dynamic "self_managed_event_source" {
-    for_each = try(each.value.self_managed_event_source, [])
-    content {
-      endpoints = self_managed_event_source.value.endpoints
-    }
-  }
-
-  dynamic "source_access_configuration" {
-    for_each = try(each.value.source_access_configuration, [])
-    content {
-      type = source_access_configuration.value["type"]
-      uri  = source_access_configuration.value["uri"]
-    }
-  }
-
-  dynamic "filter_criteria" {
-    for_each = try(each.value.filter_criteria, null) != null ? [true] : []
-
-    content {
-      filter {
-        pattern = try(each.value["filter_criteria"].pattern, null)
-      }
-    }
-  }
-}
-
-resource "aws_lambda_event_source_mapping" "with_refresh" {
-  for_each = { for k, v in var.event_source_mapping : k => v if var.create && !var.use_existing_alias && var.refresh_alias }
-
-  function_name = aws_lambda_alias.with_refresh[0].arn
+  function_name = local.alias_arn
 
   event_source_arn = try(each.value.event_source_arn, null)
 

--- a/modules/alias/outputs.tf
+++ b/modules/alias/outputs.tf
@@ -26,20 +26,20 @@ output "lambda_alias_function_version" {
 
 output "lambda_alias_event_source_mapping_function_arn" {
   description = "The the ARN of the Lambda function the event source mapping is sending events to"
-  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.function_arn } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.function_arn }
+  value       = { for k, v in aws_lambda_event_source_mapping.this : k => v.function_arn }
 }
 
 output "lambda_alias_event_source_mapping_state" {
   description = "The state of the event source mapping"
-  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.state } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.state }
+  value       = { for k, v in aws_lambda_event_source_mapping.this : k => v.state }
 }
 
 output "lambda_alias_event_source_mapping_state_transition_reason" {
   description = "The reason the event source mapping is in its current state"
-  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.state_transition_reason } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.state_transition_reason }
+  value       = { for k, v in aws_lambda_event_source_mapping.this : k => v.state_transition_reason }
 }
 
 output "lambda_alias_event_source_mapping_uuid" {
   description = "The UUID of the created event source mapping"
-  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.uuid } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.uuid }
+  value       = { for k, v in aws_lambda_event_source_mapping.this : k => v.uuid }
 }

--- a/modules/alias/outputs.tf
+++ b/modules/alias/outputs.tf
@@ -23,3 +23,23 @@ output "lambda_alias_function_version" {
   description = "Lambda function version which the alias uses"
   value       = try(data.aws_lambda_alias.existing[0].function_version, aws_lambda_alias.with_refresh[0].function_version, aws_lambda_alias.no_refresh[0].function_version, "")
 }
+
+output "lambda_alias_event_source_mapping_function_arn" {
+  description = "The the ARN of the Lambda function the event source mapping is sending events to"
+  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.function_arn } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.function_arn }
+}
+
+output "lambda_alias_event_source_mapping_state" {
+  description = "The state of the event source mapping"
+  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.state } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.state }
+}
+
+output "lambda_alias_event_source_mapping_state_transition_reason" {
+  description = "The reason the event source mapping is in its current state"
+  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.state_transition_reason } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.state_transition_reason }
+}
+
+output "lambda_alias_event_source_mapping_uuid" {
+  description = "The UUID of the created event source mapping"
+  value       = length(aws_lambda_event_source_mapping.with_refresh) > 0 ? { for k, v in aws_lambda_event_source_mapping.with_refresh : k => v.uuid } : { for k, v in aws_lambda_event_source_mapping.no_refresh : k => v.uuid }
+}

--- a/modules/alias/variables.tf
+++ b/modules/alias/variables.tf
@@ -117,3 +117,13 @@ variable "allowed_triggers" {
   type        = map(any)
   default     = {}
 }
+
+############################################
+# Lambda Event Source Mapping
+############################################
+
+variable "event_source_mapping" {
+  description = "Map of event source mapping"
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## Description
This change adds the ability to configure event source mapping on a Lambda Alias, instead of just the base Lambda. The code to configure the event source mapping was pulled from the main Lambda module and ported to the alias module.

## Motivation and Context
We extensively target a Lambda alias for all our use cases in our environment, currently setting this purely via the module isn't possible.

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

Ran terraform apply to `examples/alias` and then made my changes to the module and ran another apply. No changes were detected. Added new examples and ran another apply. Resources deployed successfully.

- [x] I have executed `pre-commit run -a` on my pull request

