### PR TITLE
feat: Add SAM Metadata resources to enable the integration with SAM CLI tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+### [3.3.1](https://github.com/terraform-aws-modules/terraform-aws-lambda/compare/v3.3.0...v3.3.1) (2022-06-17)
+
+
+### Bug Fixes
+
+* Fixed enabled attribute in Lambda Event Source Mapping by default ([#321](https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/321)) ([779b368](https://github.com/terraform-aws-modules/terraform-aws-lambda/commit/779b368781f0bf14964c2f6e306c1c9ef4690bbb))
+
 ## [3.3.0](https://github.com/terraform-aws-modules/terraform-aws-lambda/compare/v3.2.1...v3.3.0) (2022-06-16)
 
 

--- a/README.md
+++ b/README.md
@@ -655,6 +655,8 @@ No modules.
 | [aws_s3_object.lambda_package](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [local_file.archive_plan](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.archive](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.sam_metadata_aws_lambda_function_this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.sam_metadata_aws_lambda_layer_version_this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_arn.log_group_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This Terraform module is the part of [serverless.tf framework](https://github.co
 3. Create, update, and publish AWS Lambda Function and Lambda Layer - [see usage](#usage).
 4. Create static and dynamic aliases for AWS Lambda Function - [see usage](#usage), see [modules/alias](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/modules/alias).
 5. Do complex deployments (eg, rolling, canary, rollbacks, triggers) - [read more](#deployment), see [modules/deploy](https://github.com/terraform-aws-modules/terraform-aws-lambda/tree/master/modules/deploy).
+6. Use AWS SAM CLI to test Lambda Function - [read more](#sam_cli_integration).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ module "lambda_function_existing_package_from_remote_url" {
 applications. Currently, SAM CLI tool only supports CFN applications, but SAM CLI team is working on a feature to extend the testing capabilities to support terraform applications (check this [Github issue](https://github.com/aws/aws-sam-cli/issues/3154) 
 to be updated about the incoming releases, and features included in each release for the Terraform support feature).
 
-SAM CLI provides two ways of testing, local testing, and testing on-cloud (Accelerate).
+SAM CLI provides two ways of testing: local testing and testing on-cloud (Accelerate).
 
 ### Local Testing
 Using SAM CLI, you can invoke the lambda functions defined in the terraform application locally using the [sam local invoke](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-local-invoke.html)

--- a/README.md
+++ b/README.md
@@ -526,6 +526,35 @@ module "lambda_function_existing_package_from_remote_url" {
 }
 ```
 
+## <a name="sam_cli_integration"></a> How to use AWS SAM CLI to test Lambda Function?
+[AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-command-reference.html) is an open source tool that help the developers to initiate, build, test, and deploy serverless 
+applications. Currently, SAM CLI tool only supports CFN applications, but SAM CLI team is working on a feature to extend the testing capabilities to support terraform applications (check this [Github issue](https://github.com/aws/aws-sam-cli/issues/3154) 
+to be updated about the incoming releases, and features included in each release for the Terraform support feature).
+
+SAM CLI provides two ways of testing, local testing, and testing on-cloud (Accelerate).
+
+### Local Testing
+Using SAM CLI, you can invoke the lambda functions defined in the terraform application locally using the [sam local invoke](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-local-invoke.html)
+command, providing the function terraform address, or function name, and to set the `hook-package-id` to `terraform` to tell SAM CLI that the underlying project is a terraform application. 
+
+You can execute the `sam local invoke` command from your terraform application root directory as following:
+```
+sam local invoke --hook-package-id terraform module.hello_world_function.aws_lambda_function.this[0] 
+```
+You can also pass an event to your lambda function, or overwrite its environment variables. Check [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-invoke.html) for more information.
+
+You can also invoke your lambda function in debugging mode, and step-through your lambda function source code locally in your preferred editor. Check [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-debugging.html) for more information.
+
+### Testing on-cloud (Accelerate)
+You can use AWS SAM CLI to quickly test your application on your AWS development account. Using SAM Accelerate, you will be able to develop your lambda functions locally, 
+and once you save your updates, SAM CLI will update your development account with the updated Lambda functions. So, you can test it on cloud, and if there is any bug,
+you can quickly update the code, and SAM CLI will take care of pushing it to the cloud. Check [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/accelerate.html) for more information about SAM Accelerate.
+
+You can execute the `sam sync` command from your terraform application root directory as following:
+```
+sam sync --hook-package-id terraform --watch 
+```
+
 ## <a name="deployment"></a> How to deploy and manage Lambda Functions?
 
 ### Simple deployments

--- a/README.md
+++ b/README.md
@@ -712,8 +712,8 @@ No modules.
 | [aws_s3_object.lambda_package](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [local_file.archive_plan](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.archive](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.sam_metadata_aws_lambda_function_this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.sam_metadata_aws_lambda_layer_version_this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.sam_metadata_aws_lambda_function](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.sam_metadata_aws_lambda_layer_version](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_arn.log_group_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |

--- a/main.tf
+++ b/main.tf
@@ -113,11 +113,11 @@ resource "aws_lambda_function" "this" {
 # and what are the resources that contain the building logic.
 resource "null_resource" "sam_metadata_aws_lambda_function_this" {
   count = local.create && var.create_package && var.create_function && !var.create_layer ? 1 : 0
-  triggers  = {
+  triggers = {
     # This is a way to let SAM CLI correlates between the Lambda function resource, and this metadata
     # resource
-    resource_name        = "aws_lambda_function.this[0]",
-    resource_type        = "ZIP_LAMBDA_FUNCTION",
+    resource_name = "aws_lambda_function.this[0]",
+    resource_type = "ZIP_LAMBDA_FUNCTION",
 
     # The Lambda function source code.
     original_source_code = jsonencode(var.source_path),
@@ -127,7 +127,7 @@ resource "null_resource" "sam_metadata_aws_lambda_function_this" {
     source_code_property = "path",
 
     # A property to let SAM CLI knows where to find the Lambda function built output
-    built_output_path    = data.external.archive_prepare[0].result.filename
+    built_output_path = data.external.archive_prepare[0].result.filename
   }
 
   # SAM CLI can run terraform apply -target metadata resource, and this will apply the building
@@ -165,8 +165,8 @@ resource "null_resource" "sam_metadata_aws_lambda_layer_version_this" {
   triggers = {
     # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
     # resource
-    resource_name        = "aws_lambda_layer_version.this[0]",
-    resource_type        = "LAMBDA_LAYER",
+    resource_name = "aws_lambda_layer_version.this[0]",
+    resource_type = "LAMBDA_LAYER",
 
     # The Lambda layer source code.
     original_source_code = jsonencode(var.source_path),
@@ -176,7 +176,7 @@ resource "null_resource" "sam_metadata_aws_lambda_layer_version_this" {
     source_code_property = "path",
 
     # A property to let SAM CLI knows where to find the Lambda layer built output
-    built_output_path    = data.external.archive_prepare[0].result.filename
+    built_output_path = data.external.archive_prepare[0].result.filename
   }
 
   # SAM CLI can run terraform apply -target metadata resource, and this will apply the building

--- a/main.tf
+++ b/main.tf
@@ -330,7 +330,7 @@ resource "aws_lambda_function_url" "this" {
 # This resource contains the extra information required by SAM CLI to provide the testing capabilities
 # to the TF application. The required data is where SAM CLI can find the Lambda function source code
 # and what are the resources that contain the building logic.
-resource "null_resource" "sam_metadata_aws_lambda_function_this" {
+resource "null_resource" "sam_metadata_aws_lambda_function" {
   count = local.create && var.create_package && var.create_function && !var.create_layer ? 1 : 0
 
   triggers = {
@@ -358,7 +358,7 @@ resource "null_resource" "sam_metadata_aws_lambda_function_this" {
 # This resource contains the extra information required by SAM CLI to provide the testing capabilities
 # to the TF application. The required data is where SAM CLI can find the Lambda layer source code
 # and what are the resources that contain the building logic.
-resource "null_resource" "sam_metadata_aws_lambda_layer_version_this" {
+resource "null_resource" "sam_metadata_aws_lambda_layer_version" {
   count = local.create && var.create_package && var.create_layer ? 1 : 0
 
   triggers = {

--- a/main.tf
+++ b/main.tf
@@ -126,33 +126,6 @@ resource "aws_lambda_function" "this" {
   ]
 }
 
-# This resource contains the extra information required by SAM CLI to provide the testing capabilities
-# to the TF application. The required data is where SAM CLI can find the Lambda function source code
-# and what are the resources that contain the building logic.
-resource "null_resource" "sam_metadata_aws_lambda_function_this" {
-  count = local.create && var.create_package && var.create_function && !var.create_layer ? 1 : 0
-  triggers = {
-    # This is a way to let SAM CLI correlates between the Lambda function resource, and this metadata
-    # resource
-    resource_name = "aws_lambda_function.this[0]"
-    resource_type = "ZIP_LAMBDA_FUNCTION"
-
-    # The Lambda function source code.
-    original_source_code = jsonencode(var.source_path)
-
-    # a property to let SAM CLI knows where to find the Lambda function source code if the provided
-    # value for original_source_code attribute is map.
-    source_code_property = "path"
-
-    # A property to let SAM CLI knows where to find the Lambda function built output
-    built_output_path = data.external.archive_prepare[0].result.filename
-  }
-
-  # SAM CLI can run terraform apply -target metadata resource, and this will apply the building
-  # resources as well
-  depends_on = [data.external.archive_prepare, null_resource.archive]
-}
-
 resource "aws_lambda_layer_version" "this" {
   count = local.create && var.create_layer ? 1 : 0
 
@@ -172,34 +145,6 @@ resource "aws_lambda_layer_version" "this" {
   s3_object_version = local.s3_object_version
 
   depends_on = [null_resource.archive, aws_s3_object.lambda_package]
-}
-
-# This resource contains the extra information required by SAM CLI to provide the testing capabilities
-# to the TF application. The required data is where SAM CLI can find the Lambda layer source code
-# and what are the resources that contain the building logic.
-resource "null_resource" "sam_metadata_aws_lambda_layer_version_this" {
-  count = local.create && var.create_package && var.create_layer ? 1 : 0
-
-  triggers = {
-    # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
-    # resource
-    resource_name = "aws_lambda_layer_version.this[0]"
-    resource_type = "LAMBDA_LAYER"
-
-    # The Lambda layer source code.
-    original_source_code = jsonencode(var.source_path)
-
-    # a property to let SAM CLI knows where to find the Lambda layer source code if the provided
-    # value for original_source_code attribute is map.
-    source_code_property = "path"
-
-    # A property to let SAM CLI knows where to find the Lambda layer built output
-    built_output_path = data.external.archive_prepare[0].result.filename
-  }
-
-  # SAM CLI can run terraform apply -target metadata resource, and this will apply the building
-  # resources as well
-  depends_on = [data.external.archive_prepare, null_resource.archive]
 }
 
 resource "aws_s3_object" "lambda_package" {
@@ -380,4 +325,60 @@ resource "aws_lambda_function_url" "this" {
       max_age           = try(cors.value.max_age, null)
     }
   }
+}
+
+# This resource contains the extra information required by SAM CLI to provide the testing capabilities
+# to the TF application. The required data is where SAM CLI can find the Lambda function source code
+# and what are the resources that contain the building logic.
+resource "null_resource" "sam_metadata_aws_lambda_function_this" {
+  count = local.create && var.create_package && var.create_function && !var.create_layer ? 1 : 0
+
+  triggers = {
+    # This is a way to let SAM CLI correlates between the Lambda function resource, and this metadata
+    # resource
+    resource_name = "aws_lambda_function.this[0]"
+    resource_type = "ZIP_LAMBDA_FUNCTION"
+
+    # The Lambda function source code.
+    original_source_code = jsonencode(var.source_path)
+
+    # a property to let SAM CLI knows where to find the Lambda function source code if the provided
+    # value for original_source_code attribute is map.
+    source_code_property = "path"
+
+    # A property to let SAM CLI knows where to find the Lambda function built output
+    built_output_path = data.external.archive_prepare[0].result.filename
+  }
+
+  # SAM CLI can run terraform apply -target metadata resource, and this will apply the building
+  # resources as well
+  depends_on = [data.external.archive_prepare, null_resource.archive]
+}
+
+# This resource contains the extra information required by SAM CLI to provide the testing capabilities
+# to the TF application. The required data is where SAM CLI can find the Lambda layer source code
+# and what are the resources that contain the building logic.
+resource "null_resource" "sam_metadata_aws_lambda_layer_version_this" {
+  count = local.create && var.create_package && var.create_layer ? 1 : 0
+
+  triggers = {
+    # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
+    # resource
+    resource_name = "aws_lambda_layer_version.this[0]"
+    resource_type = "LAMBDA_LAYER"
+
+    # The Lambda layer source code.
+    original_source_code = jsonencode(var.source_path)
+
+    # a property to let SAM CLI knows where to find the Lambda layer source code if the provided
+    # value for original_source_code attribute is map.
+    source_code_property = "path"
+
+    # A property to let SAM CLI knows where to find the Lambda layer built output
+    built_output_path = data.external.archive_prepare[0].result.filename
+  }
+
+  # SAM CLI can run terraform apply -target metadata resource, and this will apply the building
+  # resources as well
+  depends_on = [data.external.archive_prepare, null_resource.archive]
 }

--- a/main.tf
+++ b/main.tf
@@ -116,15 +116,15 @@ resource "null_resource" "sam_metadata_aws_lambda_function_this" {
   triggers = {
     # This is a way to let SAM CLI correlates between the Lambda function resource, and this metadata
     # resource
-    resource_name = "aws_lambda_function.this[0]",
-    resource_type = "ZIP_LAMBDA_FUNCTION",
+    resource_name = "aws_lambda_function.this[0]"
+    resource_type = "ZIP_LAMBDA_FUNCTION"
 
     # The Lambda function source code.
-    original_source_code = jsonencode(var.source_path),
+    original_source_code = jsonencode(var.source_path)
 
     # a property to let SAM CLI knows where to find the Lambda function source code if the provided
     # value for original_source_code attribute is map.
-    source_code_property = "path",
+    source_code_property = "path"
 
     # A property to let SAM CLI knows where to find the Lambda function built output
     built_output_path = data.external.archive_prepare[0].result.filename
@@ -165,15 +165,15 @@ resource "null_resource" "sam_metadata_aws_lambda_layer_version_this" {
   triggers = {
     # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
     # resource
-    resource_name = "aws_lambda_layer_version.this[0]",
-    resource_type = "LAMBDA_LAYER",
+    resource_name = "aws_lambda_layer_version.this[0]"
+    resource_type = "LAMBDA_LAYER"
 
     # The Lambda layer source code.
-    original_source_code = jsonencode(var.source_path),
+    original_source_code = jsonencode(var.source_path)
 
     # a property to let SAM CLI knows where to find the Lambda layer source code if the provided
     # value for original_source_code attribute is map.
-    source_code_property = "path",
+    source_code_property = "path"
 
     # A property to let SAM CLI knows where to find the Lambda layer built output
     built_output_path = data.external.archive_prepare[0].result.filename

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -76,7 +76,7 @@ No modules.
 | [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [docker_registry_image.this](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) | resource |
-| [null_resource.sam_metadata_docker_registry_image_this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.sam_metadata_docker_registry_image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -55,6 +55,7 @@ module "docker_image" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 | <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 2.12 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
@@ -62,6 +63,7 @@ module "docker_image" {
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35 |
 | <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.12 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules
 
@@ -74,6 +76,7 @@ No modules.
 | [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [docker_registry_image.this](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) | resource |
+| [null_resource.sam_metadata_docker_registry_image_this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -26,10 +26,10 @@ resource "docker_registry_image" "this" {
 # functions. It will contain the information required to build the docker image locally.
 resource "null_resource" "sam_metadata_docker_registry_image_this" {
   triggers = {
-    resource_type     = "IMAGE_LAMBDA_FUNCTION",
-    docker_context    = var.source_path,
-    docker_file       = var.docker_file_path,
-    docker_build_args = jsonencode(var.build_args),
+    resource_type     = "IMAGE_LAMBDA_FUNCTION"
+    docker_context    = var.source_path
+    docker_file       = var.docker_file_path
+    docker_build_args = jsonencode(var.build_args)
     docker_tag        = var.image_tag
   }
   depends_on = [docker_registry_image.this]

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -21,6 +21,20 @@ resource "docker_registry_image" "this" {
   keep_remotely = var.keep_remotely
 }
 
+# This resource contains the extra information required by SAM CLI to provide the testing capabilities
+# to the TF application. This resource will maintain the metadata information about the image type lambda
+# functions. It will contain the information required to build the docker image locally.
+resource "null_resource" "sam_metadata_docker_registry_image_this" {
+  triggers = {
+    resource_type     = "IMAGE_LAMBDA_FUNCTION",
+    docker_context    = var.source_path,
+    docker_file       = var.docker_file_path,
+    docker_build_args = jsonencode(var.build_args),
+    docker_tag        = var.image_tag
+  }
+  depends_on = [docker_registry_image.this]
+}
+
 resource "aws_ecr_repository" "this" {
   count = var.create_ecr_repo ? 1 : 0
 

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -21,21 +21,6 @@ resource "docker_registry_image" "this" {
   keep_remotely = var.keep_remotely
 }
 
-# This resource contains the extra information required by SAM CLI to provide the testing capabilities
-# to the TF application. This resource will maintain the metadata information about the image type lambda
-# functions. It will contain the information required to build the docker image locally.
-resource "null_resource" "sam_metadata_docker_registry_image_this" {
-  triggers = {
-    resource_type     = "IMAGE_LAMBDA_FUNCTION"
-    docker_context    = var.source_path
-    docker_file       = var.docker_file_path
-    docker_build_args = jsonencode(var.build_args)
-    docker_tag        = var.image_tag
-    built_image_uri   = docker_registry_image.this.name
-  }
-  depends_on = [docker_registry_image.this]
-}
-
 resource "aws_ecr_repository" "this" {
   count = var.create_ecr_repo ? 1 : 0
 
@@ -55,4 +40,20 @@ resource "aws_ecr_lifecycle_policy" "this" {
 
   policy     = var.ecr_repo_lifecycle_policy
   repository = local.ecr_repo
+}
+
+# This resource contains the extra information required by SAM CLI to provide the testing capabilities
+# to the TF application. This resource will maintain the metadata information about the image type lambda
+# functions. It will contain the information required to build the docker image locally.
+resource "null_resource" "sam_metadata_docker_registry_image_this" {
+  triggers = {
+    resource_type     = "IMAGE_LAMBDA_FUNCTION"
+    docker_context    = var.source_path
+    docker_file       = var.docker_file_path
+    docker_build_args = jsonencode(var.build_args)
+    docker_tag        = var.image_tag
+    built_image_uri   = docker_registry_image.this.name
+  }
+
+  depends_on = [docker_registry_image.this]
 }

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -45,7 +45,7 @@ resource "aws_ecr_lifecycle_policy" "this" {
 # This resource contains the extra information required by SAM CLI to provide the testing capabilities
 # to the TF application. This resource will maintain the metadata information about the image type lambda
 # functions. It will contain the information required to build the docker image locally.
-resource "null_resource" "sam_metadata_docker_registry_image_this" {
+resource "null_resource" "sam_metadata_docker_registry_image" {
   triggers = {
     resource_type     = "IMAGE_LAMBDA_FUNCTION"
     docker_context    = var.source_path

--- a/modules/docker-build/versions.tf
+++ b/modules/docker-build/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "kreuzwerker/docker"
       version = ">= 2.12"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## Description
This change is to add new resources (sam_metadata_*) of type (null_resource) that will maintain some information about the lambda resources exist in the terraform application to enable the integration with SAM CLI.  SAM CLI tool is looking for the lambda resources source code, and the resources that contain the building logic of these resources. SAM CLI can use this information to extend the SAM CLI testing capabilities to the terraform applications.

## Motivation and Context
This change will enable the customers who use Serverless TF module to define Lambda resources to integrate with SAM CLI tool, and so the customers can test their applications either locally or on cloud.

## Breaking Changes
no breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
As the new resource is just to collect metadata for SAM CLI tool, so it does not require any changes from the modules users side, and so no change in the examples. So I tested that I can run `terraform apply` for the available examples without any issues.
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
