### PR TITLE
fix: Lambda should depend on policy attachments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,11 +101,28 @@ resource "aws_lambda_function" "this" {
 
   tags = var.tags
 
-  # Depending on the log group is necessary to allow Terraform to create the log group before AWS can.
-  # When a lambda function is invoked, AWS creates the log group automatically if it doesn't exist yet.
-  # Without the dependency, this can result in a race condition if the lambda function is invoked before
-  # Terraform can create the log group.
-  depends_on = [null_resource.archive, aws_s3_object.lambda_package, aws_cloudwatch_log_group.lambda]
+  depends_on = [
+    null_resource.archive,
+    aws_s3_object.lambda_package,
+
+    # Depending on the log group is necessary to allow Terraform to create the log group before AWS can.
+    # When a lambda function is invoked, AWS creates the log group automatically if it doesn't exist yet.
+    # Without the dependency, this can result in a race condition if the lambda function is invoked before
+    # Terraform can create the log group.
+    aws_cloudwatch_log_group.lambda,
+
+    # Before the lambda is created the execution role with all its policies should be ready
+    aws_iam_role_policy_attachment.additional_inline,
+    aws_iam_role_policy_attachment.additional_json,
+    aws_iam_role_policy_attachment.additional_jsons,
+    aws_iam_role_policy_attachment.additional_many,
+    aws_iam_role_policy_attachment.additional_one,
+    aws_iam_role_policy_attachment.async,
+    aws_iam_role_policy_attachment.logs,
+    aws_iam_role_policy_attachment.dead_letter,
+    aws_iam_role_policy_attachment.vpc,
+    aws_iam_role_policy_attachment.tracing,
+  ]
 }
 
 resource "aws_lambda_layer_version" "this" {


### PR DESCRIPTION
## Description
Added all policy-attachments to the deponds_on of the 'aws_lambda_function'

## Motivation and Context
When the lambda is created the execution-role with all its
policies should be in place.

Some policies like VPC are a hard requirement for lambda creation
which fill fail if they are not already in place.

Fixes #326 

## Breaking Changes
May introduce circular dependencies, where policies some how depend on the lambda.
Those policies could created / attached outside of this module.

## How Has This Been Tested?
- [x] I have tested and validated these changes using the provided `examples/with-vpc`
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
