### PR TITLE
fix: Make the archive resource change when its content changes

### DIFF
--- a/package.tf
+++ b/package.tf
@@ -59,7 +59,7 @@ resource "null_resource" "archive" {
 
   triggers = {
     filename  = data.external.archive_prepare[0].result.filename
-    timestamp = data.external.archive_prepare[0].result.timestamp
+    hash      = md5(data.external.archive_prepare[0].result.build_plan)
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION

## Description

The suggested change is to detect changes in `null_resource`  archive by hash and instead of timestamps.

## Motivation and Context

The `terraform plan` command will always show changes because the `null_resource`  archive is triggered by timestamps which makes TF runs not idempotent.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
