### PR TITLE
feat: Add support building layers in DockerInDocker scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ No modules.
 | <a name="input_docker_file"></a> [docker\_file](#input\_docker\_file) | Path to a Dockerfile when building in Docker | `string` | `""` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image to use for the build | `string` | `""` | no |
 | <a name="input_docker_pip_cache"></a> [docker\_pip\_cache](#input\_docker\_pip\_cache) | Whether to mount a shared pip cache folder into docker environment or not | `any` | `null` | no |
+| <a name="input_docker_volumes_from"></a> [docker\_volumes\_from](#input\_docker\_volumes\_from) | Another container id to mount volumes from (i.e. in DinD scenario) | `string` | `""` | no |
 | <a name="input_docker_with_ssh_agent"></a> [docker\_with\_ssh\_agent](#input\_docker\_with\_ssh\_agent) | Whether to pass SSH\_AUTH\_SOCK into docker environment or not | `bool` | `false` | no |
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | A map that defines environment variables for the Lambda Function. | `map(string)` | `{}` | no |
 | <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |

--- a/package.py
+++ b/package.py
@@ -889,6 +889,10 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
         docker_image = docker.docker_image
         docker_build_root = docker.docker_build_root
 
+        if docker_image and not docker_file:
+            docker_cmd = docker_pull_command(image=docker_image)
+            check_call(docker_cmd)
+
         if docker_image:
             ok = False
             while True:
@@ -1000,6 +1004,10 @@ def install_npm_requirements(query, requirements_file, tmp_dir):
         docker_image = docker.docker_image
         docker_build_root = docker.docker_build_root
 
+        if docker_image and not docker_file:
+            docker_cmd = docker_pull_command(image=docker_image)
+            check_call(docker_cmd)
+
         if docker_image:
             ok = False
             while True:
@@ -1062,6 +1070,13 @@ def install_npm_requirements(query, requirements_file, tmp_dir):
 
             os.remove(target_file)
             yield temp_dir
+
+def docker_pull_command(image):
+    """"""
+    docker_cmd = ['docker', 'pull', image]
+    cmd_log.info(shlex_join(docker_cmd))
+    log_handler and log_handler.flush()
+    return docker_cmd
 
 
 def docker_image_id_command(tag):

--- a/package.py
+++ b/package.py
@@ -1117,7 +1117,7 @@ def docker_run_command(build_root, command, runtime,
         raise RuntimeError("Unsupported platform for docker building")
 
     if volumes_from:
-        workdir = build_root
+        workdir = os.path.abspath(build_root)
     else:
         workdir = '/var/task'
 

--- a/package.py
+++ b/package.py
@@ -1101,15 +1101,19 @@ def docker_run_command(build_root, command, runtime,
     if platform.system() not in ('Linux', 'Darwin'):
         raise RuntimeError("Unsupported platform for docker building")
 
-    workdir = '/var/task'
+    if volumes_from:
+        workdir = build_root
+    else:
+        workdir = '/var/task'
 
     docker_cmd = ['docker', 'run', '--rm', '-w', workdir]
 
     if interactive:
         docker_cmd.append('-it')
 
-    bind_path = os.path.abspath(build_root)
-    docker_cmd.extend(['-v', "{}:{}:z".format(bind_path, workdir)])
+    if not volumes_from:
+        bind_path = os.path.abspath(build_root)
+        docker_cmd.extend(['-v', "{}:{}:z".format(bind_path, workdir)])
 
     home = os.environ['HOME']
     docker_cmd.extend([

--- a/package.tf
+++ b/package.tf
@@ -17,11 +17,11 @@ data "external" "archive_prepare" {
     })
 
     docker = var.build_in_docker ? jsonencode({
-      docker_pip_cache  = var.docker_pip_cache
-      docker_build_root = var.docker_build_root
-      docker_file       = var.docker_file
-      docker_image      = var.docker_image
-      with_ssh_agent    = var.docker_with_ssh_agent
+      docker_pip_cache    = var.docker_pip_cache
+      docker_build_root   = var.docker_build_root
+      docker_file         = var.docker_file
+      docker_image        = var.docker_image
+      with_ssh_agent      = var.docker_with_ssh_agent
       docker_volumes_from = var.docker_volumes_from
     }) : null
 

--- a/package.tf
+++ b/package.tf
@@ -22,6 +22,7 @@ data "external" "archive_prepare" {
       docker_file       = var.docker_file
       docker_image      = var.docker_image
       with_ssh_agent    = var.docker_with_ssh_agent
+      docker_volumes_from = var.docker_volumes_from
     }) : null
 
     artifacts_dir = var.artifacts_dir

--- a/variables.tf
+++ b/variables.tf
@@ -671,6 +671,12 @@ variable "docker_pip_cache" {
   default     = null
 }
 
+variable "docker_volumes_from" {
+  description = "Another container id to mount volumes from (i.e. in DinD scenario)"
+  type        = string
+  default     = ""
+}
+
 variable "recreate_missing_package" {
   description = "Whether to recreate missing Lambda package if it is missing locally or not"
   type        = bool


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We have Jenkins instances running with Docker-In-Docker and there are Pipelines using [Docker images as agent](https://www.jenkins.io/doc/book/pipeline/docker/#workspace-synchronization). I was facing problems with the docker run commands inside of this package, because the volumes for temporary directories or the current workspace/build-root could not be mounted.

The error, which occured was: `ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Give option to make building lambda layer in Docker work in Docker-In-Docker/Jenkins-Docker. To be able to do this, one need to pass the container-id of the parent container to any docker run command in the `--volumes-from` parameter.
On Jenkins this is now possible by defining `TF_VAR_docker_volume` as environent variable.

Additionally, this PR is fixing #219 by pulling the build image if needed.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
none.
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
