### PR TITLE
fix: Forces the local_filename output to wait for the package to be built

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -133,6 +133,10 @@ output "lambda_cloudwatch_log_group_name" {
 output "local_filename" {
   description = "The filename of zip archive deployed (if deployment was from local)"
   value       = local.filename
+
+  depends_on = [
+    null_resource.archive,
+  ]
 }
 
 output "s3_object" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Uses `depends_on` to force the output `local_filename` to wait until the package is available, so the output can be relied on to tailor the terraform graph in cases where the package must be available before it is used.

Fixes #355

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See #355

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

I don't believe there are any breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
