### PR TITLE
fix: Generates error in plan phase if runtime is not available

### DIFF
--- a/package.py
+++ b/package.py
@@ -656,9 +656,14 @@ class BuildPlanManager:
                 if required:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
-            else:
-                step('pip', runtime, requirements, prefix, tmp_dir)
-                hash(requirements)
+            if not shutil.which(runtime):
+                raise RuntimeError(
+                    "Python interpreter version equal "
+                    "to defined lambda runtime ({}) should be "
+                    "available in system PATH".format(runtime))
+
+            step('pip', runtime, requirements, prefix, tmp_dir)
+            hash(requirements)
 
         def npm_requirements_step(path, prefix=None, required=False, tmp_dir=None):
             requirements = path
@@ -668,9 +673,14 @@ class BuildPlanManager:
                 if required:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
-            else:
-                step('npm', runtime, requirements, prefix, tmp_dir)
-                hash(requirements)
+            if not shutil.which(runtime):
+                raise RuntimeError(
+                    "Nodejs interpreter version equal "
+                    "to defined lambda runtime ({}) should be "
+                    "available in system PATH".format(runtime))
+
+            step('npm', runtime, requirements, prefix, tmp_dir)
+            hash(requirements)
 
         def commands_step(path, commands):
             if not commands:


### PR DESCRIPTION
Fixes #357

## Description

Raises plan-time error if the python or nodejs runtime is not present in the PATH. This matches the apply-time behavior, but generates the error during the plan instead of waiting until the apply.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See #357

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

I don't think so, unless people were somehow exploiting the prior behavior. But I can't really think of a situation where anyone would _want_ a plan-time success and an apply-time failure...

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
