### PR TITLE
fix: Performs plan-phase runtime check only if building package

### DIFF
--- a/package.py
+++ b/package.py
@@ -656,14 +656,9 @@ class BuildPlanManager:
                 if required:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
-            if not shutil.which(runtime):
-                raise RuntimeError(
-                    "Python interpreter version equal "
-                    "to defined lambda runtime ({}) should be "
-                    "available in system PATH".format(runtime))
-
-            step('pip', runtime, requirements, prefix, tmp_dir)
-            hash(requirements)
+            else:
+                step('pip', runtime, requirements, prefix, tmp_dir)
+                hash(requirements)
 
         def npm_requirements_step(path, prefix=None, required=False, tmp_dir=None):
             requirements = path
@@ -673,14 +668,9 @@ class BuildPlanManager:
                 if required:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
-            if not shutil.which(runtime):
-                raise RuntimeError(
-                    "Nodejs interpreter version equal "
-                    "to defined lambda runtime ({}) should be "
-                    "available in system PATH".format(runtime))
-
-            step('npm', runtime, requirements, prefix, tmp_dir)
-            hash(requirements)
+            else:
+                step('npm', runtime, requirements, prefix, tmp_dir)
+                hash(requirements)
 
         def commands_step(path, commands):
             if not commands:

--- a/package.py
+++ b/package.py
@@ -657,6 +657,12 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
+                if not shutil.which(runtime):
+                    raise RuntimeError(
+                        "Python interpreter version equal "
+                        "to defined lambda runtime ({}) should be "
+                        "available in system PATH".format(runtime))
+
                 step('pip', runtime, requirements, prefix, tmp_dir)
                 hash(requirements)
 
@@ -669,6 +675,12 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
+                if not shutil.which(runtime):
+                    raise RuntimeError(
+                        "Nodejs interpreter version equal "
+                        "to defined lambda runtime ({}) should be "
+                        "available in system PATH".format(runtime))
+
                 step('npm', runtime, requirements, prefix, tmp_dir)
                 hash(requirements)
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->

`pip_requirements_step` and `npm_requirements_step` are executed even when there is no requirements file, and so there is no package to build. The runtime check should occur _only_ when the package is being built.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/358#issuecomment-1285685758

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
The opposite! It fixes a breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
