### PR TITLE
feat: Add support for additional Docker options and pre pip/npm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ source_path = [
 - `npm_requirements` - Controls whether to execute `npm install`. Set to `false` to disable this feature, `true` to run `npm install` with `package.json` found in `path`. Or set to another filename which you want to use instead.
 - `npm_tmp_dir` - Set the base directory to make the temporary directory for npm installs. Can be useful for Docker in Docker builds.
 - `prefix_in_zip` - If specified, will be used as a prefix inside zip-archive. By default, everything installs into the root of zip-archive.
+- `pre_package_commands` - List of commands to run before doing a `pip install` or `npm install`. Works in conjunction with `pip_requirements` and `npm_requirements`.
 
 ### Building in Docker
 
@@ -469,6 +470,17 @@ If your Lambda Function or Layer uses some dependencies you can build them in Do
 Using this module you can install dependencies from private hosts. To do this, you need for forward SSH agent:
 
     docker_with_ssh_agent = true
+
+#### Passing additional Docker options
+
+To add flexibility when building in docker, you can pass any number of additional options that you require (see [Docker run reference](https://docs.docker.com/engine/reference/run/) for available options):
+
+```hcl
+  docker_additional_options = [
+        "-e", "MY_ENV_VAR='My environment variable value'",
+        "-v", "/local:/docker-vol",
+  ] 
+```
 
 ## <a name="package"></a> Deployment package - Create or use existing
 

--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description of your Lambda Function (or Layer) | `string` | `""` | no |
 | <a name="input_destination_on_failure"></a> [destination\_on\_failure](#input\_destination\_on\_failure) | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
 | <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
+| <a name="input_docker_additional_options"></a> [docker\_additional\_options](#input\_docker\_additional\_options) | Additional options to pass to the docker run command (e.g. to set environment variables, volumes, etc.) | `list(string)` | `[]` | no |
 | <a name="input_docker_build_root"></a> [docker\_build\_root](#input\_docker\_build\_root) | Root dir where to build in Docker | `string` | `""` | no |
 | <a name="input_docker_file"></a> [docker\_file](#input\_docker\_file) | Path to a Dockerfile when building in Docker | `string` | `""` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image to use for the build | `string` | `""` | no |

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -39,6 +39,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_dir"></a> [package\_dir](#module\_package\_dir) | ../../ | n/a |
 | <a name="module_package_dir_pip_dir"></a> [package\_dir\_pip\_dir](#module\_package\_dir\_pip\_dir) | ../../ | n/a |
 | <a name="module_package_dir_with_npm_install"></a> [package\_dir\_with\_npm\_install](#module\_package\_dir\_with\_npm\_install) | ../../ | n/a |
+| <a name="module_package_dir_with_npm_install_and_additional_commands"></a> [package\_dir\_with\_npm\_install\_and\_additional\_commands](#module\_package\_dir\_with\_npm\_install\_and\_additional\_commands) | ../../ | n/a |
 | <a name="module_package_dir_without_npm_install"></a> [package\_dir\_without\_npm\_install](#module\_package\_dir\_without\_npm\_install) | ../../ | n/a |
 | <a name="module_package_dir_without_pip_install"></a> [package\_dir\_without\_pip\_install](#module\_package\_dir\_without\_pip\_install) | ../../ | n/a |
 | <a name="module_package_file"></a> [package\_file](#module\_package\_file) | ../../ | n/a |
@@ -46,6 +47,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_with_commands_and_patterns"></a> [package\_with\_commands\_and\_patterns](#module\_package\_with\_commands\_and\_patterns) | ../../ | n/a |
 | <a name="module_package_with_docker"></a> [package\_with\_docker](#module\_package\_with\_docker) | ../../ | n/a |
 | <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in\_docker](#module\_package\_with\_npm\_requirements\_in\_docker) | ../../ | n/a |
+| <a name="module_package_with_npm_requirements_in_docker_and_additional_commands"></a> [package\_with\_npm\_requirements\_in\_docker\_and\_additional\_commands](#module\_package\_with\_npm\_requirements\_in\_docker\_and\_additional\_commands) | ../../ | n/a |
 | <a name="module_package_with_patterns"></a> [package\_with\_patterns](#module\_package\_with\_patterns) | ../../ | n/a |
 | <a name="module_package_with_pip_requirements_in_docker"></a> [package\_with\_pip\_requirements\_in\_docker](#module\_package\_with\_pip\_requirements\_in\_docker) | ../../ | n/a |
 

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -79,8 +79,8 @@ module "package_file_with_pip_requirements" {
   source_path = [
     "${path.module}/../fixtures/python3.8-app1/index.py",
     {
-      pip_requirements     = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
-      prefix_in_zip        = "vendor"
+      pip_requirements = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
+      prefix_in_zip    = "vendor"
       pre_package_commands = [
         "echo I will run before the pip install command",
         "echo so will I",
@@ -104,7 +104,7 @@ module "package_with_pip_requirements_in_docker" {
     "${path.module}/../fixtures/python3.8-app1/index.py",
     "${path.module}/../fixtures/python3.8-app1/dir1/dir2",
     {
-      pip_requirements     = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
+      pip_requirements = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
       pre_package_commands = [
         "echo I will run before the pip install command in the docker container",
         "echo I can read $MY_ENV_VAR and my volume:",
@@ -113,11 +113,11 @@ module "package_with_pip_requirements_in_docker" {
     }
   ]
 
-  build_in_docker           = true
+  build_in_docker = true
   docker_additional_options = [
-        "-e", "MY_ENV_VAR='My environment variable value'",
-        "-v", "${abspath(path.module)}:/my-vol:ro",
-  ] 
+    "-e", "MY_ENV_VAR='My environment variable value'",
+    "-v", "${abspath(path.module)}:/my-vol:ro",
+  ]
 }
 
 # Create zip-archive which contains content of directory with commands and patterns applied.
@@ -256,8 +256,8 @@ module "package_dir_with_npm_install_and_additional_commands" {
   runtime = "nodejs14.x"
   source_path = [
     {
-      path                 = "${path.module}/../fixtures/nodejs14.x-app1"
-      npm_requirements     = true
+      path             = "${path.module}/../fixtures/nodejs14.x-app1"
+      npm_requirements = true
       pre_package_commands = [
         "echo I will run before the npm install command",
         "echo so will I",
@@ -301,11 +301,11 @@ module "package_with_npm_requirements_in_docker_and_additional_commands" {
 
   create_function = false
 
-  runtime         = "nodejs14.x"
+  runtime = "nodejs14.x"
   source_path = [
     {
-      path                 = "${path.module}/../fixtures/nodejs14.x-app1"
-      npm_requirements     = true
+      path             = "${path.module}/../fixtures/nodejs14.x-app1"
+      npm_requirements = true
       pre_package_commands = [
         "echo I will run before the npm install command in the docker container",
         "echo I can read $MY_ENV_VAR and my volume:",
@@ -314,13 +314,13 @@ module "package_with_npm_requirements_in_docker_and_additional_commands" {
     }
   ]
 
-  build_in_docker           = true
+  build_in_docker = true
   docker_additional_options = [
-        "-e", "MY_ENV_VAR='My environment variable value'",
-        "-v", "${abspath(path.module)}:/my-vol:ro",
-  ] 
+    "-e", "MY_ENV_VAR='My environment variable value'",
+    "-v", "${abspath(path.module)}:/my-vol:ro",
+  ]
 
-  hash_extra      = "something-unique-to-not-conflict-with-module.package_dir_with_npm_install"
+  hash_extra = "something-unique-to-not-conflict-with-module.package_dir_with_npm_install"
 }
 
 ################################

--- a/package.py
+++ b/package.py
@@ -657,7 +657,7 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
-                if not shutil.which(runtime):
+                if not query.docker and not shutil.which(runtime):
                     raise RuntimeError(
                         "Python interpreter version equal "
                         "to defined lambda runtime ({}) should be "
@@ -679,7 +679,7 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
-                if not shutil.which(runtime):
+                if not query.docker and not shutil.which(runtime):
                     raise RuntimeError(
                         "Nodejs interpreter version equal "
                         "to defined lambda runtime ({}) should be "

--- a/package.tf
+++ b/package.tf
@@ -17,11 +17,12 @@ data "external" "archive_prepare" {
     })
 
     docker = var.build_in_docker ? jsonencode({
-      docker_pip_cache  = var.docker_pip_cache
-      docker_build_root = var.docker_build_root
-      docker_file       = var.docker_file
-      docker_image      = var.docker_image
-      with_ssh_agent    = var.docker_with_ssh_agent
+      docker_pip_cache          = var.docker_pip_cache
+      docker_build_root         = var.docker_build_root
+      docker_file               = var.docker_file
+      docker_image              = var.docker_image
+      with_ssh_agent            = var.docker_with_ssh_agent
+      docker_additional_options = var.docker_additional_options
     }) : null
 
     artifacts_dir = var.artifacts_dir

--- a/variables.tf
+++ b/variables.tf
@@ -671,6 +671,12 @@ variable "docker_pip_cache" {
   default     = null
 }
 
+variable "docker_additional_options" {
+  description = "Additional options to pass to the docker run command (e.g. to set environment variables, volumes, etc.)"
+  type        = list(string)
+  default     = []
+}
+
 variable "recreate_missing_package" {
   description = "Whether to recreate missing Lambda package if it is missing locally or not"
   type        = bool


### PR DESCRIPTION
## Description
1. Have added support for additional options to be passed to the docker run command
2. Have added `pre_package_commands` to allow any number of commands to be run before running a pip or npm install
3. Have fixed where `npm_requirements = claim.get('npm_package_json')`, according to documentation and examples, this should be `npm_requirements = claim.get('npm_requirements')`
4. Have fixed issue introduced by #358/#359 raised in #361 

## Motivation and Context
I want to build my lambdas in docker containers but I need access to packages in CodeArtifact. Differences in build environments make this slightly more difficult. On build machines builds are run within containers, so I have Docker in Docker issues. On developers machines, Terraform might be running within a container or it might not. Workarounds to cope with these different environments make for some very ugly code.

Therefore, easiest option is to make these changes that allow me to pass AWS tokens in as environment variables and run a CodeArtifact login within the container before doing a pip install. I see the need to be able to do things like pass tokens as environment variables or map local config files as volumes as being quite a common scenario for people wanting to get packages from private repositories (e.g. Artifactory).

I've made the changes very generic so they're flexible. Any option can be passed to docker run so it can set environment variables, volumes etc.

The pre package commands work both for docker and non-docker builds.

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I've updated a couple of existing "build-package" tests and added a couple of new ones. In addition to that I've ran every test under examples/build-package

- [x] I have executed `pre-commit run -a` on my pull request

