### PR TITLE
fix: Skips the runtime test when building in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,10 @@ Using this module you can install dependencies from private hosts. To do this, y
 
     docker_with_ssh_agent = true
 
+Note that by default, the `docker_image` used comes from the registry `public.ecr.aws/sam/`, and will be based on the `runtime` that you specify. In other words, if you specify a runtime of `python3.8` and do not specify `docker_image`, then the `docker_image` will resolve to `public.ecr.aws/sam/build-python3.8`. This ensures that by default the `runtime` is available in the docker container.
+
+If you override `docker_image`, be sure to keep the image in sync with your `runtime`. During the plan phase, when using docker, there is no check that the `runtime` is available to build the package. That means that if you use an image that does not have the runtime, the plan will still succeed, but then the apply will fail.
+
 ## <a name="package"></a> Deployment package - Create or use existing
 
 By default, this module creates deployment package and uses it to create or update Lambda Function or Lambda Layer.

--- a/package.py
+++ b/package.py
@@ -657,7 +657,7 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
-                if not shutil.which(runtime):
+                if not query.docker and not shutil.which(runtime):
                     raise RuntimeError(
                         "Python interpreter version equal "
                         "to defined lambda runtime ({}) should be "
@@ -675,7 +675,7 @@ class BuildPlanManager:
                     raise RuntimeError(
                         'File not found: {}'.format(requirements))
             else:
-                if not shutil.which(runtime):
+                if not query.docker and not shutil.which(runtime):
                     raise RuntimeError(
                         "Nodejs interpreter version equal "
                         "to defined lambda runtime ({}) should be "


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This skips the runtime test when building in docker.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the plan phase, package.py is executed on the local machine, even when the build is configured to use docker. This means the runtime check was executed on the local machine, and therefore required that the `runtime` be present in the local machine PATH. But when using docker, the runtime should only be required in the container, not on the local machine.

Since by default the image used is based on the runtime, we skip the runtime check when using docker to build the package. However, a note is added to the readme for cases where the user customizes the `docker_image`, as that can lead to a success in the plan phase that would fail in the apply phase, if they are not careful to match up the runtime and the image.

Fixes #361

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
