### PR TITLE
feat: Support additional arguments for docker and entrypoint override

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,27 @@ Note that by default, the `docker_image` used comes from the registry `public.ec
 
 If you override `docker_image`, be sure to keep the image in sync with your `runtime`. During the plan phase, when using docker, there is no check that the `runtime` is available to build the package. That means that if you use an image that does not have the runtime, the plan will still succeed, but then the apply will fail.
 
+#### Passing additional Docker options
+
+To add flexibility when building in docker, you can pass any number of additional options that you require (see [Docker run reference](https://docs.docker.com/engine/reference/run/) for available options):
+
+```hcl
+  docker_additional_options = [
+        "-e", "MY_ENV_VAR='My environment variable value'",
+        "-v", "/local:/docker-vol",
+  ]
+```
+
+#### Overriding Docker Entrypoint
+
+To override the docker entrypoint when building in docker, set `docker_entrypoint`:
+
+```hcl
+  docker_entrypoint = "/entrypoint/entrypoint.sh"
+```
+
+The entrypoint must map to a path within your container, so you need to either build your own image that contains the entrypoint or map it to a file on the host by mounting a volume (see [Passing additional Docker options](#passing-additional-docker-options)).
+
 ## <a name="package"></a> Deployment package - Create or use existing
 
 By default, this module creates deployment package and uses it to create or update Lambda Function or Lambda Layer.
@@ -716,7 +737,9 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description of your Lambda Function (or Layer) | `string` | `""` | no |
 | <a name="input_destination_on_failure"></a> [destination\_on\_failure](#input\_destination\_on\_failure) | Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations | `string` | `null` | no |
 | <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | Amazon Resource Name (ARN) of the destination resource for successful asynchronous invocations | `string` | `null` | no |
+| <a name="input_docker_additional_options"></a> [docker\_additional\_options](#input\_docker\_additional\_options) | Additional options to pass to the docker run command (e.g. to set environment variables, volumes, etc.) | `list(string)` | `[]` | no |
 | <a name="input_docker_build_root"></a> [docker\_build\_root](#input\_docker\_build\_root) | Root dir where to build in Docker | `string` | `""` | no |
+| <a name="input_docker_entrypoint"></a> [docker\_entrypoint](#input\_docker\_entrypoint) | Path to the Docker entrypoint to use | `string` | `null` | no |
 | <a name="input_docker_file"></a> [docker\_file](#input\_docker\_file) | Path to a Dockerfile when building in Docker | `string` | `""` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image to use for the build | `string` | `""` | no |
 | <a name="input_docker_pip_cache"></a> [docker\_pip\_cache](#input\_docker\_pip\_cache) | Whether to mount a shared pip cache folder into docker environment or not | `any` | `null` | no |

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -48,6 +48,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_with_npm_requirements_in_docker"></a> [package\_with\_npm\_requirements\_in\_docker](#module\_package\_with\_npm\_requirements\_in\_docker) | ../../ | n/a |
 | <a name="module_package_with_patterns"></a> [package\_with\_patterns](#module\_package\_with\_patterns) | ../../ | n/a |
 | <a name="module_package_with_pip_requirements_in_docker"></a> [package\_with\_pip\_requirements\_in\_docker](#module\_package\_with\_pip\_requirements\_in\_docker) | ../../ | n/a |
+| <a name="module_package_with_pip_requirements_in_docker_overriding_entrypoint"></a> [package\_with\_pip\_requirements\_in\_docker\_overriding\_entrypoint](#module\_package\_with\_pip\_requirements\_in\_docker\_overriding\_entrypoint) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -150,6 +150,7 @@ module "package_with_pip_requirements_in_docker_overriding_entrypoint" {
       pip_requirements = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
     }
   ]
+  hash_extra = "package_with_pip_requirements_in_docker_overriding_entrypoint"
 
   build_in_docker = true
   docker_additional_options = [

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -107,6 +107,34 @@ module "package_with_pip_requirements_in_docker" {
   build_in_docker = true
 }
 
+# Create zip-archive which contains:
+# 1. A single file - index.py
+# 2. Content of directory "dir2"
+# 3. Install pip requirements
+# "pip install" is running in a Docker container for the specified runtime
+# The docker entrypoint is overridden, allowing you to run additional commands within the container
+module "package_with_pip_requirements_in_docker_overriding_entrypoint" {
+  source = "../../"
+
+  create_function = false
+
+  runtime = "python3.8"
+  source_path = [
+    "${path.module}/../fixtures/python3.8-app1/index.py",
+    "${path.module}/../fixtures/python3.8-app1/dir1/dir2",
+    {
+      pip_requirements = "${path.module}/../fixtures/python3.8-app1/requirements.txt"
+    }
+  ]
+
+  build_in_docker = true
+  docker_additional_options = [
+    "-e", "MY_ENV_VAR='My environment variable value'",
+    "-v", "${abspath(path.module)}/../fixtures/python3.8-app1/docker/entrypoint.sh:/entrypoint/entrypoint.sh:ro",
+  ]
+  docker_entrypoint = "/entrypoint/entrypoint.sh"
+}
+
 # Create zip-archive which contains content of directory with commands and patterns applied.
 #
 # Notes:

--- a/examples/fixtures/python3.8-app1/docker/entrypoint.sh
+++ b/examples/fixtures/python3.8-app1/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo in entrypoint
+echo I can read $MY_ENV_VAR and my volume:
+ls -la /entrypoint
+
+echo "running command $@"
+"$@"
+
+echo finished running entrypoint

--- a/package.tf
+++ b/package.tf
@@ -17,11 +17,13 @@ data "external" "archive_prepare" {
     })
 
     docker = var.build_in_docker ? jsonencode({
-      docker_pip_cache  = var.docker_pip_cache
-      docker_build_root = var.docker_build_root
-      docker_file       = var.docker_file
-      docker_image      = var.docker_image
-      with_ssh_agent    = var.docker_with_ssh_agent
+      docker_pip_cache          = var.docker_pip_cache
+      docker_build_root         = var.docker_build_root
+      docker_file               = var.docker_file
+      docker_image              = var.docker_image
+      with_ssh_agent            = var.docker_with_ssh_agent
+      docker_additional_options = var.docker_additional_options
+      docker_entrypoint         = var.docker_entrypoint
     }) : null
 
     artifacts_dir = var.artifacts_dir

--- a/variables.tf
+++ b/variables.tf
@@ -677,6 +677,18 @@ variable "docker_pip_cache" {
   default     = null
 }
 
+variable "docker_additional_options" {
+  description = "Additional options to pass to the docker run command (e.g. to set environment variables, volumes, etc.)"
+  type        = list(string)
+  default     = []
+}
+
+variable "docker_entrypoint" {
+  description = "Path to the Docker entrypoint to use"
+  type        = string
+  default     = null
+}
+
 variable "recreate_missing_package" {
   description = "Whether to recreate missing Lambda package if it is missing locally or not"
   type        = bool


### PR DESCRIPTION
## Description

1. Have added support for additional options to be passed to the docker run command
2. Have added ability to override the entrypoint in the docker run command

This PR replaces #360.  The approach here requires fewer changes to package.py, making it far easier to maintain going forwards.

## Motivation and Context
I want to build my lambdas in docker containers (because my build environment might not have the required pre-requisites installed) but I need access to packages in CodeArtifact. Differences in build environments make this slightly more difficult. On build machines builds are run within containers, so I have Docker in Docker issues. On developers machines, Terraform might be running within a container or it might not. Workarounds to cope with these different environments make for some very ugly code.

Therefore, the best option is to make these changes that allow me to pass AWS tokens in as environment variables and run a CodeArtifact login within the container (via the entrypoint) before doing a pip install. I see the need to be able to do things like pass tokens as environment variables or map local config files as volumes as being quite a common scenario for people wanting to get packages from private repositories (e.g. Artifactory), that's why I'm updating this module.

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I've run existing examples under examples/build-package and have added a new example to show how the new feature can be used

- [x] I have executed `pre-commit run -a` on my pull request
