### PR TITLE
chore: Add dedicated NACL rules to intra subnets in example with VPC and S3 Gateway endpoint

### DIFF
--- a/examples/with-vpc-s3-endpoint/README.md
+++ b/examples/with-vpc-s3-endpoint/README.md
@@ -38,8 +38,8 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_lambda_s3_write"></a> [lambda\_s3\_write](#module\_lambda\_s3\_write) | ../../ | n/a |
-| <a name="module_nacl_s3_pl"></a> [nacl\_s3\_pl](#module\_nacl\_s3\_pl) | luigidifraiawork/nacl-rules-managed-prefix-list/aws | ~> 1.1 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_s3_endpoint_inbound"></a> [s3\_endpoint\_inbound](#module\_s3\_endpoint\_inbound) | luigidifraiawork/nacl-rules-managed-prefix-list/aws | ~> 1.1 |
 | <a name="module_security_group_lambda"></a> [security\_group\_lambda](#module\_security\_group\_lambda) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 3.0 |

--- a/examples/with-vpc-s3-endpoint/README.md
+++ b/examples/with-vpc-s3-endpoint/README.md
@@ -38,6 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_lambda_s3_write"></a> [lambda\_s3\_write](#module\_lambda\_s3\_write) | ../../ | n/a |
+| <a name="module_nacl_s3_pl"></a> [nacl\_s3\_pl](#module\_nacl\_s3\_pl) | luigidifraiawork/nacl-rules-managed-prefix-list/aws | ~> 1.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_security_group_lambda"></a> [security\_group\_lambda](#module\_security\_group\_lambda) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |

--- a/examples/with-vpc-s3-endpoint/README.md
+++ b/examples/with-vpc-s3-endpoint/README.md
@@ -39,7 +39,6 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_lambda_s3_write"></a> [lambda\_s3\_write](#module\_lambda\_s3\_write) | ../../ | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
-| <a name="module_s3_endpoint_inbound"></a> [s3\_endpoint\_inbound](#module\_s3\_endpoint\_inbound) | luigidifraiawork/nacl-rules-managed-prefix-list/aws | ~> 1.1 |
 | <a name="module_security_group_lambda"></a> [security\_group\_lambda](#module\_security\_group\_lambda) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 3.0 |
@@ -49,6 +48,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Type |
 |------|------|
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_ec2_managed_prefix_list.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
 | [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/examples/with-vpc-s3-endpoint/README.md
+++ b/examples/with-vpc-s3-endpoint/README.md
@@ -38,7 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 1.0 |
 | <a name="module_lambda_s3_write"></a> [lambda\_s3\_write](#module\_lambda\_s3\_write) | ../../ | n/a |
-| <a name="module_nacl_s3_pl"></a> [nacl\_s3\_pl](#module\_nacl\_s3\_pl) | luigidifraiawork/nacl-rules-managed-prefix-list/aws | ~> 1.0 |
+| <a name="module_nacl_s3_pl"></a> [nacl\_s3\_pl](#module\_nacl\_s3\_pl) | luigidifraiawork/nacl-rules-managed-prefix-list/aws | ~> 1.1 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_security_group_lambda"></a> [security\_group\_lambda](#module\_security\_group\_lambda) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |

--- a/examples/with-vpc-s3-endpoint/main.tf
+++ b/examples/with-vpc-s3-endpoint/main.tf
@@ -59,20 +59,6 @@ data "aws_ec2_managed_prefix_list" "this" {
   name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 
-locals {
-  entries_cidr = data.aws_ec2_managed_prefix_list.this.entries[*].cidr
-  s3_endpoint_inbound_rules = [
-    for k, v in zipmap(range(length(local.entries_cidr)), local.entries_cidr) : {
-      rule_number = 200 + k
-      rule_action = "allow"
-      from_port   = 1024
-      to_port     = 65535
-      protocol    = "tcp"
-      cidr_block  = v
-    }
-  ]
-}
-
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
@@ -99,7 +85,19 @@ module "vpc" {
       },
     ],
     # NACL rules for the response traffic from addresses in the AWS S3 prefix list
-    local.s3_endpoint_inbound_rules
+    [for k, v in zipmap(
+      range(length(data.aws_ec2_managed_prefix_list.this.entries[*].cidr)),
+      data.aws_ec2_managed_prefix_list.this.entries[*].cidr
+      ) :
+      {
+        rule_number = 200 + k
+        rule_action = "allow"
+        from_port   = 1024
+        to_port     = 65535
+        protocol    = "tcp"
+        cidr_block  = v
+      }
+    ]
   )
 }
 

--- a/examples/with-vpc-s3-endpoint/main.tf
+++ b/examples/with-vpc-s3-endpoint/main.tf
@@ -72,10 +72,11 @@ resource "random_pet" "this" {
 
 module "nacl_s3_pl" {
   source  = "luigidifraiawork/nacl-rules-managed-prefix-list/aws"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   service_name = "s3"
   start_offset = 200
+  direction    = "inbound"
 }
 
 module "vpc" {

--- a/examples/with-vpc-s3-endpoint/main.tf
+++ b/examples/with-vpc-s3-endpoint/main.tf
@@ -70,7 +70,7 @@ resource "random_pet" "this" {
   length = 2
 }
 
-module "nacl_s3_pl" {
+module "s3_endpoint_inbound" {
   source  = "luigidifraiawork/nacl-rules-managed-prefix-list/aws"
   version = "~> 1.1"
 
@@ -96,7 +96,7 @@ module "vpc" {
     # NACL rule for local traffic
     local.network_acls["default_inbound"],
     # NACL rules for the response traffic from addresses in the AWS S3 prefix list
-    module.nacl_s3_pl.rules
+    module.s3_endpoint_inbound.rules
   )
 }
 


### PR DESCRIPTION
## Description
Add dedicated NACL rules for an extra layer of security and dynamically build the ones for the S3 prefix list in the current region, so that **response** traffic from the S3 endpoint is allowed to reach intra subnets where the Lambda function is attached.

## Motivation and Context
Two motivations:
- provide a complete example that also shows how to deal with NACL rules when an S3 Gateway endpoint is involved;
- gather feedback on how NACL rules are dynamically generated for AWS-managed prefix lists using the [nacl-rules-managed-prefix-list module](https://registry.terraform.io/modules/luigidifraiawork/nacl-rules-managed-prefix-list/aws/latest).

## Breaking Changes
Not aware of any.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
