### PR TITLE
fix: Qualifiers in event invoke config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ locals {
 }
 
 resource "aws_lambda_function_event_invoke_config" "this" {
-  for_each = { for k, v in local.qualifiers : k => v if local.create && var.create_function && !var.create_layer && var.create_async_event_config }
+  for_each = { for k, v in local.qualifiers : k => v if v != null && local.create && var.create_function && !var.create_layer && var.create_async_event_config }
 
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = each.key == "current_version" ? aws_lambda_function.this[0].version : null


### PR DESCRIPTION
## Description
create_current_version_async_event_config and create_unqualified_alias_async_event_config were not working due to zipmap returning a map with qualifier as key and null as value if variables were set to false

## Motivation and Context
there's currently no way to opt out of either current_version or unqualified_version for async event config

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I deployed the `examples/alias` example and modified the variables before my change, resulting in no change in terraform state. Then I applied my change and ran apply, and terraform wanted to remove the resources, as it should.
