### PR TITLE
fix: Fix installing poetry dependencies using locally installed poetry

### DIFF
--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -40,6 +40,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_dir"></a> [package\_dir](#module\_package\_dir) | ../../ | n/a |
 | <a name="module_package_dir_pip_dir"></a> [package\_dir\_pip\_dir](#module\_package\_dir\_pip\_dir) | ../../ | n/a |
 | <a name="module_package_dir_poetry"></a> [package\_dir\_poetry](#module\_package\_dir\_poetry) | ../../ | n/a |
+| <a name="module_package_dir_poetry_local"></a> [package\_dir\_poetry\_local](#module\_package\_dir\_poetry\_local) | ../../ | n/a |
 | <a name="module_package_dir_with_npm_install"></a> [package\_dir\_with\_npm\_install](#module\_package\_dir\_with\_npm\_install) | ../../ | n/a |
 | <a name="module_package_dir_without_npm_install"></a> [package\_dir\_without\_npm\_install](#module\_package\_dir\_without\_npm\_install) | ../../ | n/a |
 | <a name="module_package_dir_without_pip_install"></a> [package\_dir\_without\_pip\_install](#module\_package\_dir\_without\_pip\_install) | ../../ | n/a |

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -65,6 +65,24 @@ module "package_dir_poetry" {
   artifacts_dir = "${path.root}/builds/package_dir_poetry/"
 }
 
+# Create zip-archive of a single directory where "poetry export" & "pip install --no-deps" will also be executed
+# Note that this requires poetry to be available in system PATH
+module "package_dir_poetry_local" {
+  source = "../../"
+
+  create_function = false
+
+  runtime = "python3.9"
+
+  source_path = [
+    {
+      path           = "${path.module}/../fixtures/python3.9-app-poetry"
+      poetry_install = true
+    }
+  ]
+  artifacts_dir = "${path.root}/builds/package_dir_poetry/"
+}
+
 # Create zip-archive of a single directory without running "pip install" (which is default for python runtime)
 module "package_dir_without_pip_install" {
   source = "../../"

--- a/package.py
+++ b/package.py
@@ -688,6 +688,10 @@ class BuildPlanManager:
                 if required:
                     raise RuntimeError("poetry configuration not found: {}".format(pyproject_file))
             else:
+                if not query.docker and not shutil.which("poetry"):
+                    raise RuntimeError(
+                        "Poetry should be available in system PATH")
+
                 step("poetry", runtime, path, prefix)
                 hash(pyproject_file)
                 poetry_lock_file = os.path.join(path, "poetry.lock")
@@ -1184,7 +1188,7 @@ def install_poetry_dependencies(query, path):
                 cmd_log.info(poetry_commands)
                 log_handler and log_handler.flush()
                 for poetry_command in poetry_commands:
-                    check_call(poetry_command, env=subproc_env)
+                    check_call(poetry_command.split(), env=subproc_env)
 
             os.remove(pyproject_target_file)
             if poetry_lock_target_file:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fixes installing poetry dependencies using locally installed poetry.

Fixes #386 

## Motivation and Context
- See #386 
- Local poetry might be preferable for eg. faster build time, etc.

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
```
cd examples/build-package
terraform init
rm -rf builds/package_dir_poetry/ && terraform apply -target module.package_dir_poetry_local -auto-approve
terraform destroy -target module.package_dir_poetry_local
```