### PR TITLE
feat: Add max session duration for IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ No modules.
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_role_force_detach_policies"></a> [role\_force\_detach\_policies](#input\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |
+| <a name="input_role_maximum_session_duration"></a> [role\_maximum\_session\_duration](#input\_role\_maximum\_session\_duration) | Maximum session duration, in seconds, for the IAM role | `number` | `3600` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role to use for Lambda Function | `string` | `null` | no |
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function | `string` | `null` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -39,6 +39,8 @@ module "lambda_function" {
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
+  # role_maximum_session_duration = 7200
+
   #  attach_cloudwatch_logs_policy = false
 
   #  use_existing_cloudwatch_log_group = true

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -36,7 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lambda_function_with_efs"></a> [lambda\_function\_with\_efs](#module\_lambda\_function\_with\_efs) | ../../ | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 

--- a/examples/with-efs/main.tf
+++ b/examples/with-efs/main.tf
@@ -45,6 +45,7 @@ module "lambda_function_with_efs" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
 
   name = random_pet.this.id
   cidr = "10.10.0.0/16"

--- a/examples/with-efs/main.tf
+++ b/examples/with-efs/main.tf
@@ -44,7 +44,7 @@ module "lambda_function_with_efs" {
 ######
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
   name = random_pet.this.id

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -36,7 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lambda_function_in_vpc"></a> [lambda\_function\_in\_vpc](#module\_lambda\_function\_in\_vpc) | ../../ | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 

--- a/examples/with-vpc/main.tf
+++ b/examples/with-vpc/main.tf
@@ -31,6 +31,7 @@ module "lambda_function_in_vpc" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
 
   name = random_pet.this.id
   cidr = "10.10.0.0/16"

--- a/examples/with-vpc/main.tf
+++ b/examples/with-vpc/main.tf
@@ -30,7 +30,7 @@ module "lambda_function_in_vpc" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
   name = random_pet.this.id

--- a/iam.tf
+++ b/iam.tf
@@ -100,6 +100,7 @@ resource "aws_iam_role" "lambda" {
   force_detach_policies = var.role_force_detach_policies
   permissions_boundary  = var.role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.assume_role[0].json
+  max_session_duration  = var.role_maximum_session_duration
 
   tags = merge(var.tags, var.role_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -447,6 +447,12 @@ variable "role_tags" {
   default     = {}
 }
 
+variable "role_maximum_session_duration" {
+  description = "Maximum session duration, in seconds, for the IAM role"
+  type        = number
+  default     = 3600
+}
+
 ###########
 # Policies
 ###########


### PR DESCRIPTION
## Description
Add ability to specify [maximum session duration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#max_session_duration) for the created role.

## Motivation and Context
We're using this module to create all our services. In development, the developers assume the roles of the services to mimic the permissions they have. By default the sessions can have a maximum duration of an hour (3600 seconds) and that means that developers need to re-assume multiple times per day.

## Breaking Changes
There should be no changes as the default remains the same.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
