### PR TITLE
feat: Expose platform argument to the docker-build module

### DIFF
--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -66,6 +66,7 @@ module "docker_image" {
   build_args = {
     FOO = "bar"
   }
+  platform = "linux/amd64"
 }
 
 resource "random_pet" "this" {

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -95,6 +95,7 @@ No modules.
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag to use. If not specified current timestamp in format 'YYYYMMDDhhmmss' will be used. This can lead to unnecessary rebuilds. | `string` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |
 | <a name="input_keep_remotely"></a> [keep\_remotely](#input\_keep\_remotely) | Whether to keep Docker image in the remote registry on destroy operation. | `bool` | `false` | no |
+| <a name="input_platform"></a> [platform](#input\_platform) | The target architecture platform to build the image for. | `string` | `null` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Indicates whether images are scanned after being pushed to the repository | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | Path to folder containing application code | `string` | `null` | no |
 

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -16,6 +16,7 @@ resource "docker_registry_image" "this" {
     context    = var.source_path
     dockerfile = var.docker_file_path
     build_args = var.build_args
+    platform   = var.platform
   }
 
   keep_remotely = var.keep_remotely

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -76,3 +76,9 @@ variable "keep_remotely" {
   type        = bool
   default     = false
 }
+
+variable "platform" {
+  description = "The target architecture platform to build the image for."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description

The purpose of this PR is to add support for multi-arch or targeted arch image builds.

## Motivation and Context

Given the prevalence of multi-arch image builds these days, it's likely a good idea to expose platform target via the module.  This allows a user to define, for example: `linux/amd64` or `linux/amd64,linux/arm64`

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
