### PR TITLE
add dynamic blocks for consumer group id config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -287,6 +287,19 @@ resource "aws_lambda_event_source_mapping" "this" {
     }
   }
 
+  dynamic "self_managed_kafka_event_source_config" {
+    for_each = try(each.value.self_managed_kafka_event_source_config, [])
+    content {
+      consumer_group_id = self_managed_kafka_event_source_config.value.consumer_group_id
+    }
+  }
+  dynamic "amazon_managed_kafka_event_source_config" {
+    for_each = try(each.value.amazon_managed_kafka_event_source_config, [])
+    content {
+      consumer_group_id = amazon_managed_kafka_event_source_config.value.consumer_group_id
+    }
+  }
+
   dynamic "source_access_configuration" {
     for_each = try(each.value.source_access_configuration, [])
     content {


### PR DESCRIPTION
## Description
Add two more dynamic blocks within the lambda trigger config to allow defining kafka consumer group ids

## Motivation and Context

Fixes https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/397

## Breaking Changes
This isn't a breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
