### PR TITLE
feat: Update docker provider pin to 2.x in docker-build submodule

### DIFF
--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -54,7 +54,7 @@ module "docker_image" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 2.12 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 2.12, < 3.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
@@ -62,7 +62,7 @@ module "docker_image" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
-| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.12 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 2.12, < 3.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules

--- a/modules/docker-build/versions.tf
+++ b/modules/docker-build/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = ">= 2.12"
+      version = ">= 2.12, < 3.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## Description

The goal of this PR is to resolve docker provider deprecation issues resulting from the docker provider transition to 3.x.  This major update to the provider removes interface compatibility between `docker_image` and `docker_remote_image`.

Resolves: #398 

## Motivation and Context

Ensure the module works out of the box, until the module can be updated to use the latest variant of the `docker` provider implementation.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

