### PR TITLE
feat: Support maximum concurrency of Lambda with SQS as an event source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.77.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/examples/alias/main.tf
+++ b/examples/alias/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/async/main.tf
+++ b/examples/async/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/code-signing/main.tf
+++ b/examples/code-signing/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -8,7 +8,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/deploy/main.tf
+++ b/examples/deploy/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -24,8 +24,9 @@ module "lambda_function" {
 
   event_source_mapping = {
     sqs = {
-      event_source_arn        = aws_sqs_queue.this.arn
-      function_response_types = ["ReportBatchItemFailures"]
+      event_source_arn                = aws_sqs_queue.this.arn
+      function_response_types         = ["ReportBatchItemFailures"]
+      maximum_concurrency_sqs_scaling = "2"
     }
     dynamodb = {
       event_source_arn           = aws_dynamodb_table.this.stream_arn

--- a/examples/multiple-regions/main.tf
+++ b/examples/multiple-regions/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -14,7 +13,6 @@ provider "aws" {
   alias  = "us-east-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -3,7 +3,6 @@ provider "aws" {
   #  region = "us-east-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/triggers/main.tf
+++ b/examples/triggers/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-efs/main.tf
+++ b/examples/with-efs/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-vpc-s3-endpoint/main.tf
+++ b/examples/with-vpc-s3-endpoint/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-vpc/main.tf
+++ b/examples/with-vpc/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/main.tf
+++ b/main.tf
@@ -280,6 +280,16 @@ resource "aws_lambda_event_source_mapping" "this" {
     }
   }
 
+  dynamic "scaling_config" {
+    for_each = try(each.value.maximum_concurrency_sqs_scaling, null) != null ? [true] : []
+    content {
+      on_failure {
+        maximum_concurrency = each.value["maximum_concurrency_sqs_scaling"]
+      }
+    }
+  }
+
+
   dynamic "self_managed_event_source" {
     for_each = try(each.value.self_managed_event_source, [])
     content {

--- a/main.tf
+++ b/main.tf
@@ -283,9 +283,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   dynamic "scaling_config" {
     for_each = try(each.value.maximum_concurrency_sqs_scaling, null) != null ? [true] : []
     content {
-      on_failure {
-        maximum_concurrency = each.value["maximum_concurrency_sqs_scaling"]
-      }
+      maximum_concurrency = maximum_concurrency_sqs_scaling.value
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -291,9 +291,9 @@ resource "aws_lambda_event_source_mapping" "this" {
   }
 
   dynamic "scaling_config" {
-    for_each = try(each.value.maximum_concurrency_sqs_scaling, null) != null ? [true] : []
+    for_each = try([each.value.scaling_config], [])
     content {
-      maximum_concurrency = maximum_concurrency_sqs_scaling.value
+      maximum_concurrency = try(scaling_config.value.maximum_concurrency, null)
     }
   }
 


### PR DESCRIPTION
## Description
Aws recently introduced maximum concurrency of lambda functions when using sqs as an event source ( https://aws.amazon.com/it/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/ ), i've added the support of this feature to this module.  
This is my first contribution to this repo, please check the code since i might be wrong.

## Motivation and Context
Limiting lambda concurrency with SQS without setting reserved concurrency.

## Breaking Changes
If you want to set maximum_concurrency_sqs_scaling you need the aws provider >= 4.51.0, because the support for scaling_config has been introduced in 4.51.0: https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4510-january-19-2023

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
