### PR TITLE
feat: Add snap_start functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ No modules.
 | <a name="input_s3_object_tags_only"></a> [s3\_object\_tags\_only](#input\_s3\_object\_tags\_only) | Set to true to not merge tags with s3\_object\_tags. Useful to avoid breaching S3 Object 10 tag limit. | `bool` | `false` | no |
 | <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | Directory name where artifacts should be stored in the S3 bucket. If unset, the path from `artifacts_dir` is used | `string` | `null` | no |
 | <a name="input_s3_server_side_encryption"></a> [s3\_server\_side\_encryption](#input\_s3\_server\_side\_encryption) | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
-| <a name="input_snap_start_apply_on"></a> [snap\_start\_apply\_on](#input\_snap\_start\_apply\_on) | Conditions where snap start is enabled. Valid values are "PublishedVersions". | `string` | `null` | no |
+| <a name="input_snap_start"></a> [snap\_start](#input\_snap\_start) | (Optional) Snap start settings for low-latency startups | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | <a name="input_store_on_s3"></a> [store\_on\_s3](#input\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ No modules.
 | <a name="input_s3_object_tags_only"></a> [s3\_object\_tags\_only](#input\_s3\_object\_tags\_only) | Set to true to not merge tags with s3\_object\_tags. Useful to avoid breaching S3 Object 10 tag limit. | `bool` | `false` | no |
 | <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | Directory name where artifacts should be stored in the S3 bucket. If unset, the path from `artifacts_dir` is used | `string` | `null` | no |
 | <a name="input_s3_server_side_encryption"></a> [s3\_server\_side\_encryption](#input\_s3\_server\_side\_encryption) | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
+| <a name="input_snap_start_apply_on"></a> [snap\_start\_apply\_on](#input\_snap\_start\_apply\_on) | Conditions where snap start is enabled. Valid values are "PublishedVersions". | `string` | `null` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | <a name="input_store_on_s3"></a> [store\_on\_s3](#input\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.44 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |

--- a/README.md
+++ b/README.md
@@ -658,8 +658,8 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.44 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
@@ -668,7 +668,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.44 |
 | <a name="provider_external"></a> [external](#provider\_external) | >= 1.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -54,6 +54,8 @@ module "lambda_function" {
   #  create_package         = false
   #  local_existing_package = data.null_data_source.downloaded_package.outputs["filename"]
 
+  # snap_start = true
+
   #  policy_json = <<EOF
   #{
   #    "Version": "2012-10-17",

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,14 @@ resource "aws_lambda_function" "this" {
     }
   }
 
+  dynamic "snap_start" {
+    for_each = var.snap_start_apply_on == null ? [] : [true]
+
+    content {
+      apply_on = var.snap_start_apply_on
+    }
+  }
+
   tags = var.tags
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "this" {
   runtime                        = var.package_type != "Zip" ? null : var.runtime
   layers                         = var.layers
   timeout                        = var.lambda_at_edge ? min(var.timeout, 30) : var.timeout
-  publish                        = var.lambda_at_edge ? true : var.publish
+  publish                        = (var.lambda_at_edge || var.snap_start) ? true : var.publish
   kms_key_arn                    = var.kms_key_arn
   image_uri                      = var.image_uri
   package_type                   = var.package_type
@@ -103,10 +103,10 @@ resource "aws_lambda_function" "this" {
   }
 
   dynamic "snap_start" {
-    for_each = var.snap_start_apply_on == null ? [] : [true]
+    for_each = var.snap_start ? [true] : []
 
     content {
-      apply_on = var.snap_start_apply_on
+      apply_on = "PublishedVersions"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,12 @@ variable "image_config_working_directory" {
   default     = null
 }
 
+variable "snap_start_apply_on" {
+  description = "Conditions where snap start is enabled"
+  type        = string
+  default     = null
+}
+
 ###############
 # Function URL
 ###############

--- a/variables.tf
+++ b/variables.tf
@@ -217,10 +217,10 @@ variable "image_config_working_directory" {
   default     = null
 }
 
-variable "snap_start_apply_on" {
-  description = "Conditions where snap start is enabled"
-  type        = string
-  default     = null
+variable "snap_start" {
+  description = "(Optional) Snap start settings for low-latency startups"
+  type        = bool
+  default     = false
 }
 
 ###############

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.44"
     }
     external = {
       source  = "hashicorp/external"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Implement SnapStart for Java Lambdas.

References:

https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
https://aws.amazon.com/blogs/compute/starting-up-faster-with-aws-lambda-snapstart/
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#snap_start

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add support for SnapStart enabled lambdas.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
_N/A_.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
