### PR TITLE
feat: Update deprecated ressource docker_registry_image

### DIFF
--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -19,7 +19,7 @@ resource "docker_image" "this" {
     platform   = var.platform
   }
 
-  keep_locally = var.keep_remotely
+  keep_locally = var.keep_locally
 }
 
 resource "aws_ecr_repository" "this" {

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -9,7 +9,7 @@ locals {
   ecr_image_name = format("%v/%v:%v", local.ecr_address, local.ecr_repo, local.image_tag)
 }
 
-resource "docker_registry_image" "this" {
+resource "docker_image" "this" {
   name = local.ecr_image_name
 
   build {
@@ -19,7 +19,7 @@ resource "docker_registry_image" "this" {
     platform   = var.platform
   }
 
-  keep_remotely = var.keep_remotely
+  keep_locally = var.keep_remotely
 }
 
 resource "aws_ecr_repository" "this" {
@@ -53,8 +53,8 @@ resource "null_resource" "sam_metadata_docker_registry_image" {
     docker_file       = var.docker_file_path
     docker_build_args = jsonencode(var.build_args)
     docker_tag        = var.image_tag
-    built_image_uri   = docker_registry_image.this.name
+    built_image_uri   = docker_image.this.name
   }
 
-  depends_on = [docker_registry_image.this]
+  depends_on = [docker_image.this]
 }

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -71,7 +71,7 @@ variable "ecr_repo_lifecycle_policy" {
   default     = null
 }
 
-variable "keep_remotely" {
+variable "keep_locally" {
   description = "Whether to keep Docker image in the remote registry on destroy operation."
   type        = bool
   default     = false


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Updated the ressource " docker_registry_image" to "docker_image".
Also updated the variable "keep_remotely" to "keep_locally"
 
## Motivation and Context
Following the error :
╷
│ Warning: Argument is deprecated
│ 
│   with module.docker_image.docker_registry_image.this,
│   on .terraform/modules/docker_image/modules/docker-build/main.tf line 12, in resource "docker_registry_image" "this":
│   12: resource "docker_registry_image" "this" {
│ 
│ Use `docker_image` resource instead. This field will be removed in the next major release.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
