### PR TITLE
fix: Add resource dependency on aws_lambda_function_event_invoke_config to avoid ResourceConflictException

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ No modules.
 | [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
+| [aws_lambda_function_event_invoke_config.unqualified_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_function_url.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_url) | resource |
 | [aws_lambda_layer_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [aws_lambda_permission.current_version_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |

--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -135,6 +135,7 @@ No modules.
 | [aws_lambda_alias.no_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
 | [aws_lambda_alias.with_refresh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
 | [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_lambda_function_event_invoke_config.qualified_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_permission.qualified_alias_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.version_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |


### PR DESCRIPTION
## Description
Updated creation of aws_lambda_function_event_invoke_config resources so that there is a dependency. This is to force synchronous processing. 

## Motivation and Context
Fixes open issue https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/419
When these resources are created asynchronously, they can cause a racing condition error: `The EventInvokeConfig for function arn:aws:lambda:eu-central-1:<ACCOUNT_ID>:function:tracking-enrichment-stage-search-enriched-to-aurora:$LATEST could not be updated due to a concurrent update operation.` By adding a synchronous dependency, this is resolved.

## Breaking Changes
It does not break backward compatibility.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
I did not update an example, as the alias example already had the necessary values available.

- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I executed deployment of the alias example. I then re-deployed it with my changes.
With the update, a state change will take place for these resources. The change is as follows:
module.lambda_function.aws_lambda_function_event_invoke_config.this["unqualified_alias"] >> module.lambda_function.aws_lambda_function_event_invoke_config.unqualified_alias["unqualified_alias"]
module.alias_no_refresh.aws_lambda_function_event_invoke_config.this["qualified_alias"] >> module.alias_no_refresh.aws_lambda_function_event_invoke_config.qualified_alias["qualified_alias"]

I also deployed the component fresh. Both scenarios deployed with no issues.

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
