### PR TITLE
fix: Add if condition for empty hash_extra

### DIFF
--- a/package.py
+++ b/package.py
@@ -1430,7 +1430,8 @@ def prepare_command(args):
     content_hash = bpm.hash(hash_extra_paths)
     content_hash.update(json.dumps(build_plan, sort_keys=True).encode())
     content_hash.update(runtime.encode())
-    content_hash.update(hash_extra.encode())
+    if hash_extra:
+        content_hash.update(hash_extra.encode())
     content_hash = content_hash.hexdigest()
 
     # Generate a unique filename based on the hash.


### PR DESCRIPTION
## Description
### EDIT
Thanks to @alabonne-ca for pointing out that this issue is resolved upstream at the provider level here: https://github.com/hashicorp/terraform-provider-external/issues/193. It still could be worth merging since it would prevent this issue from resurfacing down the line if this were to come up again?

### Original Post
We suddenly ran into an issue in our work where we get the error:
```
Error: External Program Execution Failed
```
where the root cause of the error was:
```
│     content_hash.update(hash_extra.encode())
│                         ^^^^^^^^^^^^^^^^^
│ AttributeError: 'NoneType' object has no attribute 'encode'
```
We do not use the `hash_extra` variable, and looking in the code we noted that it was the only variable which is able to be the empty string on which the Python `str.encode()` function is used. In order to circumvent this issue, I simply added an if condition to make sure that it was populated before running the `.encode()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
It should not.

## How Has This Been Tested?
Only local testing
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
