### PR TITLE
fix: Pass docker object to docker_run_command to fix #427

### DIFF
--- a/package.py
+++ b/package.py
@@ -1173,6 +1173,7 @@ def install_poetry_dependencies(query, path):
                         shell=True,
                         ssh_agent=with_ssh_agent,
                         poetry_cache_dir=poetry_cache_dir,
+                        docker=docker,
                     )
                 )
             else:


### PR DESCRIPTION
Resolves #427 

Root issue is that `docker_additional_options` was added by https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/366 after I started working on adding poetry support in #311, and it was merged before, and I missed it during rebasing.