### PR TITLE
fix: Pass `--platform=manylinux2014` to `pip install`

### DIFF
--- a/package.py
+++ b/package.py
@@ -980,10 +980,16 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
         # Install dependencies into the temporary directory.
         with cd(temp_dir):
             pip_command = [
-                python_exec, '-m', 'pip',
-                'install', '--no-compile',
-                '--prefix=', '--target=.',
-                '--requirement={}'.format(requirements_filename),
+                python_exec,
+                "-m",
+                "pip",
+                "install",
+                "--no-compile",
+                "--only-binary=:all:",
+                "--platform=manylinux2014_x86_64",
+                "--prefix=",
+                "--target=.",
+                "--requirement={}".format(requirements_filename),
             ]
             if docker:
                 with_ssh_agent = docker.with_ssh_agent
@@ -1140,6 +1146,7 @@ def install_poetry_dependencies(query, path):
                     "install",
                     "--no-compile",
                     "--no-deps",
+                    "--platform=manylinux2014_x86_64",
                     "--prefix=",
                     "--target=.",
                     "--requirement=requirements.txt",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

As mentioned in [AWS documentation](https://repost.aws/knowledge-center/lambda-python-package-compatible), the `--platform=manylinux2014` parameter must be passed to `pip install` for versions of packages with compiled binaries  compatible with Lambda runtimes to be installed.

Not doing so causes wrong versions of python wheel packages to be installed when applying a terraform configuration with Lambda resources on platforms with a newer glibc than Lambda supports.

This results in runtime errors like this one with recent cryptography packages:
```
/lib64/libc.so.6: version `GLIBC_2.28' not found (required by /opt/python/cryptography/hazmat/bindings/_rust.abi3.so
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/346

### For reference:

* `python3.7` runtime uses Amazon Linux 1 with glibc 2.17
* `python3.8` and `python3.9` runtime use Amazon Linux 2 with glibc 2.26
* `manylinux2014` supports glibc 2.17

https://repost.aws/knowledge-center/lambda-python-package-compatible
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
https://aws.amazon.com/fr/amazon-linux-2/faqs/
https://peps.python.org/pep-0599/#the-manylinux2014-policy
https://github.com/pyca/cryptography/issues/6391

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
