### PR TITLE
feat: Rebuild deployment package on architecture change

### DIFF
--- a/package.py
+++ b/package.py
@@ -1411,9 +1411,9 @@ def prepare_command(args):
 
     tf_paths = query.paths
     runtime = query.runtime
-    compatible_runtimes = query.compatible_runtimes
-    architectures = query.architectures
-    compatible_architectures = query.compatible_architectures
+    compatible_runtimes = sorted(query.compatible_runtimes)
+    architectures = sorted(query.architectures) if query.architectures != "null" else []
+    compatible_architectures = sorted(query.compatible_architectures) if query.compatible_architectures != "null" else []
     artifacts_dir = query.artifacts_dir
     hash_extra_paths = query.hash_extra_paths
     source_path = query.source_path
@@ -1433,9 +1433,9 @@ def prepare_command(args):
     content_hash = bpm.hash(hash_extra_paths)
     content_hash.update(json.dumps(build_plan, sort_keys=True).encode())
     content_hash.update(runtime.encode())
-    content_hash.update(json.dumps(compatible_runtimes, sort_keys=True).encode())
-    content_hash.update(json.dumps(architectures, sort_keys=True).encode())
-    content_hash.update(json.dumps(compatible_architectures, sort_keys=True).encode())
+    content_hash.update(json.dumps(compatible_runtimes).encode())
+    content_hash.update(json.dumps(architectures).encode())
+    content_hash.update(json.dumps(compatible_architectures).encode())
     content_hash.update(hash_extra.encode())
     content_hash = content_hash.hexdigest()
 

--- a/package.py
+++ b/package.py
@@ -1411,7 +1411,9 @@ def prepare_command(args):
 
     tf_paths = query.paths
     runtime = query.runtime
+    compatible_runtimes = query.compatible_runtimes
     architectures = query.architectures
+    compatible_architectures = query.compatible_architectures
     artifacts_dir = query.artifacts_dir
     hash_extra_paths = query.hash_extra_paths
     source_path = query.source_path
@@ -1431,7 +1433,9 @@ def prepare_command(args):
     content_hash = bpm.hash(hash_extra_paths)
     content_hash.update(json.dumps(build_plan, sort_keys=True).encode())
     content_hash.update(runtime.encode())
+    content_hash.update(json.dumps(compatible_runtimes, sort_keys=True).encode())
     content_hash.update(json.dumps(architectures, sort_keys=True).encode())
+    content_hash.update(json.dumps(compatible_architectures, sort_keys=True).encode())
     content_hash.update(hash_extra.encode())
     content_hash = content_hash.hexdigest()
 
@@ -1456,7 +1460,9 @@ def prepare_command(args):
     build_data = {
         'filename': filename,
         'runtime': runtime,
+        'compatible_runtimes': compatible_runtimes,
         'architectures': architectures,
+        'compatible_architectures': compatible_architectures,
         'artifacts_dir': artifacts_dir,
         'build_plan': build_plan,
     }

--- a/package.py
+++ b/package.py
@@ -1411,7 +1411,7 @@ def prepare_command(args):
 
     tf_paths = query.paths
     runtime = query.runtime
-    function_name = query.function_name
+    architectures = query.architectures
     artifacts_dir = query.artifacts_dir
     hash_extra_paths = query.hash_extra_paths
     source_path = query.source_path
@@ -1431,6 +1431,7 @@ def prepare_command(args):
     content_hash = bpm.hash(hash_extra_paths)
     content_hash.update(json.dumps(build_plan, sort_keys=True).encode())
     content_hash.update(runtime.encode())
+    content_hash.update(json.dumps(architectures, sort_keys=True).encode())
     content_hash.update(hash_extra.encode())
     content_hash = content_hash.hexdigest()
 
@@ -1455,6 +1456,7 @@ def prepare_command(args):
     build_data = {
         'filename': filename,
         'runtime': runtime,
+        'architectures': architectures,
         'artifacts_dir': artifacts_dir,
         'build_plan': build_plan,
     }

--- a/package.tf
+++ b/package.tf
@@ -28,7 +28,7 @@ data "external" "archive_prepare" {
 
     artifacts_dir            = var.artifacts_dir
     runtime                  = var.runtime
-    compatible_runtimes      = var.compatible_runtimes
+    compatible_runtimes      = jsonencode(var.compatible_runtimes)
     architectures            = jsonencode(var.architectures)
     compatible_architectures = jsonencode(var.compatible_architectures)
     source_path              = jsonencode(var.source_path)

--- a/package.tf
+++ b/package.tf
@@ -28,6 +28,7 @@ data "external" "archive_prepare" {
 
     artifacts_dir = var.artifacts_dir
     runtime       = var.runtime
+    architectures = jsonencode(var.architectures)
     source_path   = jsonencode(var.source_path)
     hash_extra    = var.hash_extra
     hash_extra_paths = jsonencode(

--- a/package.tf
+++ b/package.tf
@@ -26,11 +26,13 @@ data "external" "archive_prepare" {
       docker_entrypoint         = var.docker_entrypoint
     }) : null
 
-    artifacts_dir = var.artifacts_dir
-    runtime       = var.runtime
-    architectures = jsonencode(var.architectures)
-    source_path   = jsonencode(var.source_path)
-    hash_extra    = var.hash_extra
+    artifacts_dir            = var.artifacts_dir
+    runtime                  = var.runtime
+    compatible_runtimes      = var.compatible_runtimes
+    architectures            = jsonencode(var.architectures)
+    compatible_architectures = jsonencode(var.compatible_architectures)
+    source_path              = jsonencode(var.source_path)
+    hash_extra               = var.hash_extra
     hash_extra_paths = jsonencode(
       [
         # Temporary fix when building from multiple locations


### PR DESCRIPTION
## Description

Rebuild the deployment package on CPU architecture change.

## Motivation and Context

Previously the CPU architecture configured for an AWS Lambda Function wasn't taken into account when generating the file name hash for the deployment package. This meant that changing the CPU architecture of an AWS Lambda Function did not trigger a rebuild of the deployment package. As deployment packages might contain CPU-specific binaries, this could've caused deployments breaking AWS Lambda Functions.

## Breaking Changes

As the file name hash changes due to these changes, a rebuild of all deployment packages will happen once using a version of this Terraform module with the changes included.

Also not really a breaking change, but a minor annoyance of the current implementation is that switching from an unconfigured CPU architecture to `x86-64` will also result in a rebuild of the deployment package, as that results in a switch of the value for the architecture from `null` to `["x86-64"]`. However, I'm not sure what'd be the best way to fix that and as it only happens when intentionally changing the architecture attribute, I believe it's fine as is as well.

