### PR TITLE
feat: Support maximum concurrency of Lambda Alias with SQS as an event source

### DIFF
--- a/examples/alias/main.tf
+++ b/examples/alias/main.tf
@@ -74,8 +74,9 @@ module "alias_no_refresh" {
 
   event_source_mapping = {
     sqs = {
-      service          = "sqs"
-      event_source_arn = module.sqs_events.sqs_queue_arn
+      service             = "sqs"
+      event_source_arn    = module.sqs_events.sqs_queue_arn
+      maximum_concurrency = 10
     }
   }
 

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -141,6 +141,13 @@ resource "aws_lambda_event_source_mapping" "this" {
     }
   }
 
+  dynamic "scaling_config" {
+    for_each = try([each.value.scaling_config], [])
+    content {
+      maximum_concurrency = try(scaling_config.value.maximum_concurrency, null)
+    }
+  }
+
   dynamic "self_managed_event_source" {
     for_each = try(each.value.self_managed_event_source, [])
     content {


### PR DESCRIPTION
## Description
PR #402 introduced maximum concurrency to lambda functions.
As I use Aliases, I've added this feature to their module

This is also my first contribution to this repo.

## Motivation and Context
Limiting lambda concurrency with SQS without setting reserved concurrency, while using Lambda Aliases

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
