### PR TITLE
Add support for java17 to validation check

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "runtime" {
   default     = ""
 
   #  validation {
-  #    condition     = can(var.create && contains(["nodejs10.x", "nodejs12.x", "java8", "java11", "python2.7", " python3.6", "python3.7", "python3.8", "dotnetcore2.1", "dotnetcore3.1", "go1.x", "ruby2.5", "ruby2.7", "provided"], var.runtime))
+  #    condition     = can(var.create && contains(["nodejs10.x", "nodejs12.x", "java8", "java11", "java17, "python2.7", " python3.6", "python3.7", "python3.8", "dotnetcore2.1", "dotnetcore3.1", "go1.x", "ruby2.5", "ruby2.7", "provided"], var.runtime))
   #    error_message = "The runtime value must be one of supported by AWS Lambda."
   #  }
 }


### PR DESCRIPTION
## Description
AWS now supports java17 runtime https://aws.amazon.com/about-aws/whats-new/2023/04/aws-lambda-java-17/

## Motivation and Context
Currently failing validation despite java17 being available

## Breaking Changes
None

## How Has This Been Tested?
None
