### PR TITLE
feat: Add CloudWatch Logs Lambda trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ No modules.
 | [aws_iam_role_policy_attachment.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_cloudwatch_log_subscription_filter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_function_url.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_url) | resource |
@@ -786,6 +787,7 @@ No modules.
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | A map that defines environment variables for the Lambda Function. | `map(string)` | `{}` | no |
 | <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | Amount of ephemeral storage (/tmp) in MB your Lambda Function can use at runtime. Valid value between 512 MB to 10,240 MB (10 GB). | `number` | `512` | no |
 | <a name="input_event_source_mapping"></a> [event\_source\_mapping](#input\_event\_source\_mapping) | Map of event source mapping | `any` | `{}` | no |
+| <a name="input_cloudwatch_logs_triggers"></a> [cloudwatch\_logs\_triggers](#input\_cloudwatch\_logs\_triggers) | Map of CloudWatch Logs subscription filters as Lambda triggers | `any` | `{}` | no |
 | <a name="input_file_system_arn"></a> [file\_system\_arn](#input\_file\_system\_arn) | The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system. | `string` | `null` | no |
 | <a name="input_file_system_local_mount_path"></a> [file\_system\_local\_mount\_path](#input\_file\_system\_local\_mount\_path) | The path where the function can access the file system, starting with /mnt/. | `string` | `null` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for your Lambda Function | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -343,6 +343,15 @@ resource "aws_lambda_event_source_mapping" "this" {
   }
 }
 
+resource "aws_cloudwatch_log_subscription_filter" "this" {
+  for_each = { for k, v in var.cloudwatch_logs_triggers : k => v if local.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers }
+
+  name            = try(each.key, null)
+  log_group_name  = try(each.value.log_group_name, null)
+  filter_pattern  = try(each.value.filter_pattern, null)
+  destination_arn = aws_lambda_function.this[0].arn
+}
+
 resource "aws_lambda_function_url" "this" {
   count = local.create && var.create_function && !var.create_layer && var.create_lambda_function_url ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -391,6 +391,12 @@ variable "event_source_mapping" {
   default     = {}
 }
 
+variable "cloudwatch_logs_triggers" {
+  description = "Map of CloudWatch Logs subscription filters as Lambda triggers"
+  type        = any
+  default     = {}
+}
+
 #################
 # CloudWatch Logs
 #################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add CloudWatch Logs trigger support

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The intent of this change is to recreate the behavior of AWS Console Lambda view (Add trigger -> CloudWatch Logs).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
tested with the complete example
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
