### PR TITLE
feat: Build and deploy go for arm64

### DIFF
--- a/package.tf
+++ b/package.tf
@@ -28,6 +28,7 @@ data "external" "archive_prepare" {
 
     artifacts_dir = var.artifacts_dir
     runtime       = var.runtime
+    architectures = var.architectures[0]
     source_path   = jsonencode(var.source_path)
     hash_extra    = var.hash_extra
     hash_extra_paths = jsonencode(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR builds the go code before zipping and deploying when the runtime is `provided.al2` and the code file ends with `.go` and the architecture is `arm64`. Might be a start for solving #455.

### Desired improvements
Some improvements I would like to add with additional input.

- Currently it is hardcoded for `arm64` architecture  I want this to be set programmatically.
- No Docker support.
- Go files are also included in the Zip (not only the binary).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change the process of building the go code for `provided.al2` runtime is automated. 

<!--- If it fixes an open issue, please link to the issue here. -->
Partly solves #455. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
I don't think it breaks anything. Only thing that is added are some additional cases in the if-statements.

<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
