### PR TITLE
fix: Fixed npm install on Windows without having to use wsl

### DIFF
--- a/package.py
+++ b/package.py
@@ -1240,12 +1240,16 @@ def install_npm_requirements(query, requirements_file, tmp_dir):
         shutil.copyfile(requirements_file, target_file)
 
         subproc_env = None
-        if not docker and OSX:
-            subproc_env = os.environ.copy()
+        npm_exec = 'npm'
+        if not docker:
+            if WINDOWS:
+                npm_exec = 'npm.cmd'
+            elif OSX:
+                subproc_env = os.environ.copy()
 
         # Install dependencies into the temporary directory.
         with cd(temp_dir):
-            npm_command = ['npm', 'install']
+            npm_command = [npm_exec, 'install']
             if docker:
                 with_ssh_agent = docker.with_ssh_agent
                 chown_mask = '{}:{}'.format(os.getuid(), os.getgid())


### PR DESCRIPTION
## Description

Use of npm.cmd on WINDOWS instead of npm within install_npm_requirements method

## Motivation and Context

https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/414 describes the issue, it has been closed with the resolution that WSL should be used. While this is a solution not all development teams use WSL. Additionally, the package.py already contains specific WINDOWS handling anyway (e.g. for python).

Fixes https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/414

## Breaking Changes

no breaking change imho

## How Has This Been Tested?

locally on my Windows machine.