### PR TITLE
feat: Allows tags to be provided only to the function

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ No modules.
 | <a name="input_file_system_arn"></a> [file\_system\_arn](#input\_file\_system\_arn) | The Amazon Resource Name (ARN) of the Amazon EFS Access Point that provides access to the file system. | `string` | `null` | no |
 | <a name="input_file_system_local_mount_path"></a> [file\_system\_local\_mount\_path](#input\_file\_system\_local\_mount\_path) | The path where the function can access the file system, starting with /mnt/. | `string` | `null` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for your Lambda Function | `string` | `""` | no |
+| <a name="input_function_tags"></a> [function\_tags](#input\_function\_tags) | A map of tags to assign only to the lambda function | `map(string)` | `{}` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
 | <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -172,6 +172,10 @@ module "lambda_function" {
     delete = "20m"
   }
 
+  function_tags = {
+    Language = "python"
+  }
+
   tags = {
     Module = "lambda1"
   }

--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "aws_lambda_function" "this" {
     delete = try(var.timeouts.delete, null)
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.function_tags)
 
   depends_on = [
     null_resource.archive,

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "function_tags" {
+  description = "A map of tags to assign only to the lambda function"
+  type        = map(string)
+  default     = {}
+}
+
 variable "s3_object_tags" {
   description = "A map of tags to assign to S3 bucket object."
   type        = map(string)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -33,6 +33,7 @@ module "wrapper" {
   vpc_subnet_ids                               = try(each.value.vpc_subnet_ids, var.defaults.vpc_subnet_ids, null)
   vpc_security_group_ids                       = try(each.value.vpc_security_group_ids, var.defaults.vpc_security_group_ids, null)
   tags                                         = try(each.value.tags, var.defaults.tags, {})
+  function_tags                                = try(each.value.function_tags, var.defaults.function_tags, {})
   s3_object_tags                               = try(each.value.s3_object_tags, var.defaults.s3_object_tags, {})
   s3_object_tags_only                          = try(each.value.s3_object_tags_only, var.defaults.s3_object_tags_only, false)
   package_type                                 = try(each.value.package_type, var.defaults.package_type, "Zip")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds a `function_tags` input to allow function-only tags to be passed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We would like to configure tags that are specific to the lambda function and not any other resources created under this module.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

We have also tested using this feature against our internal infrastructure.
