### PR TITLE
feat: Add source_code_hash var

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ No modules.
 | <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | Directory name where artifacts should be stored in the S3 bucket. If unset, the path from `artifacts_dir` is used | `string` | `null` | no |
 | <a name="input_s3_server_side_encryption"></a> [s3\_server\_side\_encryption](#input\_s3\_server\_side\_encryption) | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
 | <a name="input_snap_start"></a> [snap\_start](#input\_snap\_start) | (Optional) Snap start settings for low-latency startups | `bool` | `false` | no |
+| <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | The function's source code hash value, which overrides this module's computed hash. Set if it's not possible to determine the final source code hash until apply time. | `string` | `null` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | <a name="input_store_on_s3"></a> [store\_on\_s3](#input\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ locals {
   s3_key            = var.s3_existing_package != null ? try(var.s3_existing_package.key, null) : (var.store_on_s3 ? var.s3_prefix != null ? format("%s%s", var.s3_prefix, replace(local.archive_filename_string, "/^.*//", "")) : replace(local.archive_filename_string, "/^\\.//", "") : null)
   s3_object_version = var.s3_existing_package != null ? try(var.s3_existing_package.version_id, null) : (var.store_on_s3 ? try(aws_s3_object.lambda_package[0].version_id, null) : null)
 
+  computed_source_code_hash = (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
 }
 
 resource "aws_lambda_function" "this" {
@@ -52,7 +53,7 @@ resource "aws_lambda_function" "this" {
   }
 
   filename         = local.filename
-  source_code_hash = var.ignore_source_code_hash ? null : (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
+  source_code_hash = var.ignore_source_code_hash ? null : (var.source_code_hash != null ? var.source_code_hash : local.computed_source_code_hash)
 
   s3_bucket         = local.s3_bucket
   s3_key            = local.s3_key

--- a/variables.tf
+++ b/variables.tf
@@ -648,6 +648,12 @@ variable "local_existing_package" {
   default     = null
 }
 
+variable "source_code_hash" {
+  description = "The function's source code hash value, which overrides this module's computed hash. Set if it's not possible to determine the final source code hash until apply time."
+  type        = string
+  default     = null
+}
+
 variable "s3_existing_package" {
   description = "The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use"
   type        = map(string)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -104,6 +104,7 @@ module "wrapper" {
   s3_prefix                                    = try(each.value.s3_prefix, var.defaults.s3_prefix, null)
   ignore_source_code_hash                      = try(each.value.ignore_source_code_hash, var.defaults.ignore_source_code_hash, false)
   local_existing_package                       = try(each.value.local_existing_package, var.defaults.local_existing_package, null)
+  source_code_hash                             = try(each.value.source_code_hash, var.defaults.source_code_hash, null)
   s3_existing_package                          = try(each.value.s3_existing_package, var.defaults.s3_existing_package, null)
   store_on_s3                                  = try(each.value.store_on_s3, var.defaults.store_on_s3, false)
   s3_object_storage_class                      = try(each.value.s3_object_storage_class, var.defaults.s3_object_storage_class, "ONEZONE_IA")


### PR DESCRIPTION
## Description

This PR adds a `source_code_hash` variable which overrides the computed hash using a user-supplied value.

## Motivation and Context

This change is needed when you are using a lambda zip which is created by Terraform.
Terraform's plan will pick up the hash from an existing zip file.
If the zip file is recreated at apply time, the hash will change and the plan will become inconsistent, leading to an error like this:
```
╷
│ Error: Provider produced inconsistent final plan
│ 
│ When expanding the plan for module.foo_lambda.module.lambda.aws_lambda_function.this[0] to include new values learned so far during
│ apply, provider "registry.terraform.io/hashicorp/aws" produced an invalid new value for .source_code_hash: was cty.StringVal("2v4cb4VO4El5iGo7/SQ3bLn/lEcSUJAI8o4FBB8u6w0="), but now
│ cty.StringVal("MXbLA/B/BhPwZpVrpD81N27nytZJJ9lXxylwWW5aL0M=").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

There are lots of issues in the AWS provider like this but I'm not sure if they are caused by this exact use case so I won't link them here.

## Breaking Changes

No breaking changes; the source code hash is still computed by default.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I tested this in my own project.
