### PR TITLE
feat: Commands should fail the build if their exit code is not zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ source_path = [
 - If you specify a source path as a string that references a folder and the runtime begins with `python` or `nodejs`, the build process will automatically build python and nodejs dependencies if `requirements.txt` or `package.json` file will be found in the source folder. If you want to customize this behavior, please use the object notation as explained below.
 - All arguments except `path` are optional.
 - `patterns` - List of Python regex filenames should satisfy. Default value is "include everything" which is equal to `patterns = [".*"]`. This can also be specified as multiline heredoc string (no comments allowed). Some examples of valid patterns:
+- If you use the `commands` option and chain multiple commands, only the exit code of last command will be checked for success. If you prefer to fail fast, start the commands with the bash option `set -e` or powershell option `$ErrorActionPreference="Stop"`
 
 ```txt
     !.*/.*\.txt        # Filter all txt files recursively

--- a/package.py
+++ b/package.py
@@ -914,17 +914,27 @@ class BuildPlanManager:
                             # XXX: timestamp=0 - what actually do with it?
                             zs.write_dirs(rd, prefix=prefix, timestamp=0)
             elif cmd == "sh":
-                r, w = os.pipe()
-                side_ch = os.fdopen(r)
                 path, script = action[1:]
-                script = "{}\npwd >&{}".format(script, w)
+                p = subprocess.Popen(
+                    script,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=path,
+                )
 
-                p = subprocess.Popen(script, shell=True, cwd=path, pass_fds=(w,))
-                os.close(w)
-                sh_work_dir = side_ch.read().strip()
                 p.wait()
-                log.info("WD: %s", sh_work_dir)
-                side_ch.close()
+                call_stdout, call_stderr = p.communicate()
+                exit_code = p.returncode
+                log.info("exit_code: %s", exit_code)
+                if exit_code != 0:
+                    raise RuntimeError(
+                        "Script did not run successfully, exit code {}: {} - {}".format(
+                            exit_code,
+                            call_stdout.decode("utf-8").strip(),
+                            call_stderr.decode("utf-8").strip(),
+                        )
+                    )
             elif cmd == "set:filter":
                 patterns = action[1]
                 pf = ZipContentFilter(args=self._args)

--- a/tests/test_package_toml.py
+++ b/tests/test_package_toml.py
@@ -1,4 +1,6 @@
-from package import get_build_system_from_pyproject_toml
+from package import get_build_system_from_pyproject_toml, BuildPlanManager
+from pytest import raises
+from unittest.mock import Mock
 
 
 def test_get_build_system_from_pyproject_toml_inexistent():
@@ -12,6 +14,22 @@ def test_get_build_system_from_pyproject_toml_unknown():
     assert (
         get_build_system_from_pyproject_toml("fixtures/pyproject-unknown.toml") is None
     )
+
+
+def test_build_manager_sucess_command():
+    bpm = BuildPlanManager(args=Mock())
+    # Should not have exception raised
+    bpm.execute(build_plan=[["sh", "/tmp", "pwd"]], zip_stream=None, query=None)
+
+
+def test_build_manager_failing_command():
+    bpm = BuildPlanManager(args=Mock())
+    with raises(Exception):
+        bpm.execute(
+            build_plan=[["sh", "/tmp", "NOTACOMMAND"]],
+            zip_stream=None,
+            query=None,
+        )
 
 
 def test_get_build_system_from_pyproject_toml_poetry():


### PR DESCRIPTION
## Description
When running with some source_path setting a command:
```
source_path = [
        {
          "commands" = XYZ
        }
```
It might happen the commands fails and we want to fail the terraform deployment

## Motivation and Context
Before packaging we needed to set some auth token for npm resources. In some rare cases the authentication failed but the build carried on.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
