### PR TITLE
feat: Added support to override default tags of provider in S3 object

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ No modules.
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket to store artifacts | `string` | `null` | no |
 | <a name="input_s3_existing_package"></a> [s3\_existing\_package](#input\_s3\_existing\_package) | The S3 bucket object with keys bucket, key, version pointing to an existing zip-file to use | `map(string)` | `null` | no |
 | <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | Specifies a custom KMS key to use for S3 object encryption. | `string` | `null` | no |
+| <a name="input_s3_object_override_default_tags"></a> [s3\_object\_override\_default\_tags](#input\_s3\_object\_override\_default\_tags) | Whether to override the default\_tags from provider? NB: S3 objects support a maximum of 10 tags. | `bool` | `false` | no |
 | <a name="input_s3_object_storage_class"></a> [s3\_object\_storage\_class](#input\_s3\_object\_storage\_class) | Specifies the desired Storage Class for the artifact uploaded to S3. Can be either STANDARD, REDUCED\_REDUNDANCY, ONEZONE\_IA, INTELLIGENT\_TIERING, or STANDARD\_IA. | `string` | `"ONEZONE_IA"` | no |
 | <a name="input_s3_object_tags"></a> [s3\_object\_tags](#input\_s3\_object\_tags) | A map of tags to assign to S3 bucket object. | `map(string)` | `{}` | no |
 | <a name="input_s3_object_tags_only"></a> [s3\_object\_tags\_only](#input\_s3\_object\_tags\_only) | Set to true to not merge tags with s3\_object\_tags. Useful to avoid breaching S3 Object 10 tag limit. | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -33,6 +33,12 @@ module "lambda_function" {
   s3_bucket   = module.s3_bucket.s3_bucket_id
   s3_prefix   = "lambda-builds/"
 
+  s3_object_override_default_tags = true
+  s3_object_tags = {
+    S3ObjectName = "lambda1"
+    Override     = "true"
+  }
+
   artifacts_dir = "${path.root}/.terraform/lambda-builds/"
 
   layers = [

--- a/main.tf
+++ b/main.tf
@@ -190,6 +190,16 @@ resource "aws_s3_object" "lambda_package" {
 
   tags = var.s3_object_tags_only ? var.s3_object_tags : merge(var.tags, var.s3_object_tags)
 
+  dynamic "override_provider" {
+    for_each = var.s3_object_override_default_tags ? [true] : []
+
+    content {
+      default_tags {
+        tags = {}
+      }
+    }
+  }
+
   depends_on = [null_resource.archive]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -282,6 +282,12 @@ variable "invoke_mode" {
   default     = null
 }
 
+variable "s3_object_override_default_tags" {
+  description = "Whether to override the default_tags from provider? NB: S3 objects support a maximum of 10 tags."
+  type        = bool
+  default     = false
+}
+
 ########
 # Layer
 ########

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -111,6 +111,7 @@ module "wrapper" {
   s3_bucket                                    = try(each.value.s3_bucket, var.defaults.s3_bucket, null)
   s3_existing_package                          = try(each.value.s3_existing_package, var.defaults.s3_existing_package, null)
   s3_kms_key_id                                = try(each.value.s3_kms_key_id, var.defaults.s3_kms_key_id, null)
+  s3_object_override_default_tags              = try(each.value.s3_object_override_default_tags, var.defaults.s3_object_override_default_tags, false)
   s3_object_storage_class                      = try(each.value.s3_object_storage_class, var.defaults.s3_object_storage_class, "ONEZONE_IA")
   s3_object_tags                               = try(each.value.s3_object_tags, var.defaults.s3_object_tags, {})
   s3_object_tags_only                          = try(each.value.s3_object_tags_only, var.defaults.s3_object_tags_only, false)


### PR DESCRIPTION
## Description
Inspired by https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/pull/261 to workaround the limitation of 10 tags for S3 objects.