### PR TITLE
fix: Dont raise FileNotFoundError from close() on tmpfile rename

### DIFF
--- a/package.py
+++ b/package.py
@@ -317,7 +317,10 @@ class ZipWriteStream:
         if failed:
             os.unlink(self._tmp_filename)
         else:
-            os.replace(self._tmp_filename, self.filename)
+            try:
+                os.replace(self._tmp_filename, self.filename)
+            except FileNotFoundError:
+                pass
 
     def __enter__(self):
         return self.open()

--- a/package.py
+++ b/package.py
@@ -314,6 +314,8 @@ class ZipWriteStream:
     def close(self, failed=False):
         self._zip.close()
         self._zip = None
+        if not os.exists(self._tmp_filename):
+            return        
         if failed:
             os.unlink(self._tmp_filename)
         else:

--- a/package.py
+++ b/package.py
@@ -315,7 +315,7 @@ class ZipWriteStream:
         self._zip.close()
         self._zip = None
         if not os.exists(self._tmp_filename):
-            return        
+            return
         if failed:
             os.unlink(self._tmp_filename)
         else:

--- a/package.py
+++ b/package.py
@@ -319,10 +319,7 @@ class ZipWriteStream:
         if failed:
             os.unlink(self._tmp_filename)
         else:
-            try:
-                os.replace(self._tmp_filename, self.filename)
-            except FileNotFoundError:
-                pass
+            os.replace(self._tmp_filename, self.filename)
 
     def __enter__(self):
         return self.open()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow `FileNotFoundError` to be ignored on `close()` to compensate for file already being renamed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There appear to be some conditions by which the `self._tmp_filename` file has already been renamed/moved to `self.filename` prior to (or racing with) the calling of `close()`.

In this case `FileNotFoundError` will be thrown, causing the Terraform to fail. But without changing anything, a subsequent run of the Terraform will succeed because the ZIP file already exists. (aka: it was created correctly on the first pass)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
