### PR TITLE
feat: Allow ignoring changes in image_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ No modules.
 | [aws_iam_role_policy_attachment.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
-| [aws_lambda_function.this_ignore_image_uri](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.this_ignore_image_uri_changes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_function_url.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_url) | resource |
 | [aws_lambda_layer_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
@@ -796,7 +796,7 @@ No modules.
 | <a name="input_function_tags"></a> [function\_tags](#input\_function\_tags) | A map of tags to assign only to the lambda function | `map(string)` | `{}` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
-| <a name="input_ignore_image_uri"></a> [ignore\_image\_uri](#input\_ignore\_image\_uri) | Whether to ignore changes to the image\_uri attribute. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
+| <a name="input_ignore_image_uri_changes"></a> [ignore\_image\_uri\_changes](#input\_ignore\_image\_uri\_changes) | Whether to ignore changes to the image\_uri attribute. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
 | <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ No modules.
 | [aws_iam_role_policy_attachment.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_event_source_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.this_ignore_image_uri](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_function_url.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_url) | resource |
 | [aws_lambda_layer_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
@@ -795,6 +796,7 @@ No modules.
 | <a name="input_function_tags"></a> [function\_tags](#input\_function\_tags) | A map of tags to assign only to the lambda function | `map(string)` | `{}` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Lambda Function entrypoint in your code | `string` | `""` | no |
 | <a name="input_hash_extra"></a> [hash\_extra](#input\_hash\_extra) | The string to add into hashing function. Useful when building same source path for different functions. | `string` | `""` | no |
+| <a name="input_ignore_image_uri"></a> [ignore\_image\_uri](#input\_ignore\_image\_uri) | Whether to ignore changes to the image\_uri attribute. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
 | <a name="input_ignore_source_code_hash"></a> [ignore\_source\_code\_hash](#input\_ignore\_source\_code\_hash) | Whether to ignore changes to the function's source code hash. Set to true if you manage infrastructure and code deployments separately. | `bool` | `false` | no |
 | <a name="input_image_config_command"></a> [image\_config\_command](#input\_image\_config\_command) | The CMD for the docker image | `list(string)` | `[]` | no |
 | <a name="input_image_config_entry_point"></a> [image\_config\_entry\_point](#input\_image\_config\_entry\_point) | The ENTRYPOINT for the docker image | `list(string)` | `[]` | no |

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -37,6 +37,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_docker_image"></a> [docker\_image](#module\_docker\_image) | ../../modules/docker-build | n/a |
 | <a name="module_lambda_function_from_container_image"></a> [lambda\_function\_from\_container\_image](#module\_lambda\_function\_from\_container\_image) | ../../ | n/a |
+| <a name="module_lambda_function_from_container_image_ignore_changes_image_tag"></a> [lambda\_function\_from\_container\_image\_ignore\_changes\_image\_tag](#module\_lambda\_function\_from\_container\_image\_ignore\_changes\_image\_tag) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -49,6 +49,24 @@ module "lambda_function_from_container_image" {
   image_uri = module.docker_image.image_uri
 }
 
+module "lambda_function_from_container_image_ignore_changes_image_tag" {
+  source = "../../"
+
+  function_name = "${random_pet.this.id}-lambda-from-container-image"
+  description   = "My awesome lambda function from container image (ignore changes image tag)"
+
+  create_package = false
+
+  ##################
+  # Container Image
+  ##################
+  package_type  = "Image"
+  architectures = ["arm64"] # ["x86_64"]
+
+  image_uri        = module.docker_image.image_uri
+  ignore_image_uri = true
+}
+
 module "docker_image" {
   source = "../../modules/docker-build"
 

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -52,7 +52,7 @@ module "lambda_function_from_container_image" {
 module "lambda_function_from_container_image_ignore_changes_image_tag" {
   source = "../../"
 
-  function_name = "${random_pet.this.id}-lambda-from-container-image"
+  function_name = "${random_pet.this.id}-lambda-from-container-image-ignore-image-tag-changes"
   description   = "My awesome lambda function from container image (ignore changes image tag)"
 
   create_package = false

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -63,8 +63,8 @@ module "lambda_function_from_container_image_ignore_changes_image_tag" {
   package_type  = "Image"
   architectures = ["arm64"] # ["x86_64"]
 
-  image_uri        = module.docker_image.image_uri
-  ignore_image_uri = true
+  image_uri                = module.docker_image.image_uri
+  ignore_image_uri_changes = true
 }
 
 module "docker_image" {

--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,9 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  create                       = var.create && var.putin_khuylo
-  create_with_ignore_image_uri = var.ignore_image_uri && var.image_uri != null
-  aws_lambda_function_this     = try(aws_lambda_function.this_ignore_image_uri[0], null) != null ? aws_lambda_function.this_ignore_image_uri : aws_lambda_function.this
+  create                               = var.create && var.putin_khuylo
+  create_with_ignore_image_uri_changes = var.ignore_image_uri_changes && var.image_uri != null
+  aws_lambda_function_this             = try(aws_lambda_function.this_ignore_image_uri_changes[0], null) != null ? aws_lambda_function.this_ignore_image_uri_changes : aws_lambda_function.this
 
   archive_filename        = try(data.external.archive_prepare[0].result.filename, null)
   archive_filename_string = local.archive_filename != null ? local.archive_filename : ""
@@ -24,7 +24,7 @@ locals {
 }
 
 resource "aws_lambda_function" "this" {
-  count = local.create && var.create_function && !var.create_layer && !local.create_with_ignore_image_uri ? 1 : 0
+  count = local.create && var.create_function && !var.create_layer && !local.create_with_ignore_image_uri_changes ? 1 : 0
 
   function_name                      = var.function_name
   description                        = var.description
@@ -164,8 +164,8 @@ resource "aws_lambda_function" "this" {
 }
 
 
-resource "aws_lambda_function" "this_ignore_image_uri" {
-  count = local.create && var.create_function && !var.create_layer && local.create_with_ignore_image_uri ? 1 : 0
+resource "aws_lambda_function" "this_ignore_image_uri_changes" {
+  count = local.create && var.create_function && !var.create_layer && local.create_with_ignore_image_uri_changes ? 1 : 0
 
   function_name                      = var.function_name
   description                        = var.description

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,9 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  create = var.create && var.putin_khuylo
+  create                       = var.create && var.putin_khuylo
+  create_with_ignore_image_uri = var.ignore_image_uri && var.image_uri != null
+  aws_lambda_function_this     = try(aws_lambda_function.this_ignore_image_uri[0], null) != null ? aws_lambda_function.this_ignore_image_uri : aws_lambda_function.this
 
   archive_filename        = try(data.external.archive_prepare[0].result.filename, null)
   archive_filename_string = local.archive_filename != null ? local.archive_filename : ""
@@ -22,7 +24,7 @@ locals {
 }
 
 resource "aws_lambda_function" "this" {
-  count = local.create && var.create_function && !var.create_layer ? 1 : 0
+  count = local.create && var.create_function && !var.create_layer && !local.create_with_ignore_image_uri ? 1 : 0
 
   function_name                      = var.function_name
   description                        = var.description
@@ -161,6 +163,153 @@ resource "aws_lambda_function" "this" {
   ]
 }
 
+
+resource "aws_lambda_function" "this_ignore_image_uri" {
+  count = local.create && var.create_function && !var.create_layer && local.create_with_ignore_image_uri ? 1 : 0
+
+  function_name                      = var.function_name
+  description                        = var.description
+  role                               = var.create_role ? aws_iam_role.lambda[0].arn : var.lambda_role
+  handler                            = var.package_type != "Zip" ? null : var.handler
+  memory_size                        = var.memory_size
+  reserved_concurrent_executions     = var.reserved_concurrent_executions
+  runtime                            = var.package_type != "Zip" ? null : var.runtime
+  layers                             = var.layers
+  timeout                            = var.lambda_at_edge ? min(var.timeout, 30) : var.timeout
+  publish                            = (var.lambda_at_edge || var.snap_start) ? true : var.publish
+  kms_key_arn                        = var.kms_key_arn
+  image_uri                          = var.image_uri
+  package_type                       = var.package_type
+  architectures                      = var.architectures
+  code_signing_config_arn            = var.code_signing_config_arn
+  replace_security_groups_on_destroy = var.replace_security_groups_on_destroy
+  replacement_security_group_ids     = var.replacement_security_group_ids
+
+  /* ephemeral_storage is not supported in gov-cloud region, so it should be set to `null` */
+  dynamic "ephemeral_storage" {
+    for_each = var.ephemeral_storage_size == null ? [] : [true]
+
+    content {
+      size = var.ephemeral_storage_size
+    }
+  }
+
+  filename         = local.filename
+  source_code_hash = var.ignore_source_code_hash ? null : (local.filename == null ? false : fileexists(local.filename)) && !local.was_missing ? filebase64sha256(local.filename) : null
+
+  s3_bucket         = local.s3_bucket
+  s3_key            = local.s3_key
+  s3_object_version = local.s3_object_version
+
+  dynamic "image_config" {
+    for_each = length(var.image_config_entry_point) > 0 || length(var.image_config_command) > 0 || var.image_config_working_directory != null ? [true] : []
+    content {
+      entry_point       = var.image_config_entry_point
+      command           = var.image_config_command
+      working_directory = var.image_config_working_directory
+    }
+  }
+
+  dynamic "environment" {
+    for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]
+    content {
+      variables = var.environment_variables
+    }
+  }
+
+  dynamic "dead_letter_config" {
+    for_each = var.dead_letter_target_arn == null ? [] : [true]
+    content {
+      target_arn = var.dead_letter_target_arn
+    }
+  }
+
+  dynamic "tracing_config" {
+    for_each = var.tracing_mode == null ? [] : [true]
+    content {
+      mode = var.tracing_mode
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_subnet_ids != null && var.vpc_security_group_ids != null ? [true] : []
+    content {
+      security_group_ids = var.vpc_security_group_ids
+      subnet_ids         = var.vpc_subnet_ids
+    }
+  }
+
+  dynamic "file_system_config" {
+    for_each = var.file_system_arn != null && var.file_system_local_mount_path != null ? [true] : []
+    content {
+      local_mount_path = var.file_system_local_mount_path
+      arn              = var.file_system_arn
+    }
+  }
+
+  dynamic "snap_start" {
+    for_each = var.snap_start ? [true] : []
+
+    content {
+      apply_on = "PublishedVersions"
+    }
+  }
+
+  dynamic "logging_config" {
+    # Dont create logging config on gov cloud as it is not avaible.
+    # See https://github.com/hashicorp/terraform-provider-aws/issues/34810
+    for_each = data.aws_partition.current.partition == "aws" ? [true] : []
+
+    content {
+      log_group             = var.logging_log_group
+      log_format            = var.logging_log_format
+      application_log_level = var.logging_log_format == "Text" ? null : var.logging_application_log_level
+      system_log_level      = var.logging_log_format == "Text" ? null : var.logging_system_log_level
+    }
+  }
+
+  dynamic "timeouts" {
+    for_each = length(var.timeouts) > 0 ? [true] : []
+
+    content {
+      create = try(var.timeouts.create, null)
+      update = try(var.timeouts.update, null)
+      delete = try(var.timeouts.delete, null)
+    }
+  }
+
+  tags = merge(var.tags, var.function_tags)
+
+  depends_on = [
+    null_resource.archive,
+    aws_s3_object.lambda_package,
+
+    # Depending on the log group is necessary to allow Terraform to create the log group before AWS can.
+    # When a lambda function is invoked, AWS creates the log group automatically if it doesn't exist yet.
+    # Without the dependency, this can result in a race condition if the lambda function is invoked before
+    # Terraform can create the log group.
+    aws_cloudwatch_log_group.lambda,
+
+    # Before the lambda is created the execution role with all its policies should be ready
+    aws_iam_role_policy_attachment.additional_inline,
+    aws_iam_role_policy_attachment.additional_json,
+    aws_iam_role_policy_attachment.additional_jsons,
+    aws_iam_role_policy_attachment.additional_many,
+    aws_iam_role_policy_attachment.additional_one,
+    aws_iam_role_policy_attachment.async,
+    aws_iam_role_policy_attachment.logs,
+    aws_iam_role_policy_attachment.dead_letter,
+    aws_iam_role_policy_attachment.vpc,
+    aws_iam_role_policy_attachment.tracing,
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      image_uri,
+    ]
+  }
+}
+
 resource "aws_lambda_layer_version" "this" {
   count = local.create && var.create_layer ? 1 : 0
 
@@ -228,8 +377,8 @@ resource "aws_cloudwatch_log_group" "lambda" {
 resource "aws_lambda_provisioned_concurrency_config" "current_version" {
   count = local.create && var.create_function && !var.create_layer && var.provisioned_concurrent_executions > -1 ? 1 : 0
 
-  function_name = aws_lambda_function.this[0].function_name
-  qualifier     = aws_lambda_function.this[0].version
+  function_name = local.aws_lambda_function_this[0].function_name
+  qualifier     = local.aws_lambda_function_this[0].version
 
   provisioned_concurrent_executions = var.provisioned_concurrent_executions
 }
@@ -241,8 +390,8 @@ locals {
 resource "aws_lambda_function_event_invoke_config" "this" {
   for_each = { for k, v in local.qualifiers : k => v if v != null && local.create && var.create_function && !var.create_layer && var.create_async_event_config }
 
-  function_name = aws_lambda_function.this[0].function_name
-  qualifier     = each.key == "current_version" ? aws_lambda_function.this[0].version : null
+  function_name = local.aws_lambda_function_this[0].function_name
+  qualifier     = each.key == "current_version" ? local.aws_lambda_function_this[0].version : null
 
   maximum_event_age_in_seconds = var.maximum_event_age_in_seconds
   maximum_retry_attempts       = var.maximum_retry_attempts
@@ -270,8 +419,8 @@ resource "aws_lambda_function_event_invoke_config" "this" {
 resource "aws_lambda_permission" "current_version_triggers" {
   for_each = { for k, v in var.allowed_triggers : k => v if local.create && var.create_function && !var.create_layer && var.create_current_version_allowed_triggers }
 
-  function_name = aws_lambda_function.this[0].function_name
-  qualifier     = aws_lambda_function.this[0].version
+  function_name = local.aws_lambda_function_this[0].function_name
+  qualifier     = local.aws_lambda_function_this[0].version
 
   statement_id       = try(each.value.statement_id, each.key)
   action             = try(each.value.action, "lambda:InvokeFunction")
@@ -286,7 +435,7 @@ resource "aws_lambda_permission" "current_version_triggers" {
 resource "aws_lambda_permission" "unqualified_alias_triggers" {
   for_each = { for k, v in var.allowed_triggers : k => v if local.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers }
 
-  function_name = aws_lambda_function.this[0].function_name
+  function_name = local.aws_lambda_function_this[0].function_name
 
   statement_id       = try(each.value.statement_id, each.key)
   action             = try(each.value.action, "lambda:InvokeFunction")
@@ -300,7 +449,7 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 resource "aws_lambda_event_source_mapping" "this" {
   for_each = { for k, v in var.event_source_mapping : k => v if local.create && var.create_function && !var.create_layer && var.create_unqualified_alias_allowed_triggers }
 
-  function_name = aws_lambda_function.this[0].arn
+  function_name = local.aws_lambda_function_this[0].arn
 
   event_source_arn = try(each.value.event_source_arn, null)
 
@@ -380,10 +529,10 @@ resource "aws_lambda_event_source_mapping" "this" {
 resource "aws_lambda_function_url" "this" {
   count = local.create && var.create_function && !var.create_layer && var.create_lambda_function_url ? 1 : 0
 
-  function_name = aws_lambda_function.this[0].function_name
+  function_name = local.aws_lambda_function_this[0].function_name
 
   # Error: error creating Lambda Function URL: ValidationException
-  qualifier          = var.create_unqualified_alias_lambda_function_url ? null : aws_lambda_function.this[0].version
+  qualifier          = var.create_unqualified_alias_lambda_function_url ? null : local.aws_lambda_function_this[0].version
   authorization_type = var.authorization_type
   invoke_mode        = var.invoke_mode
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 # Lambda Function
 output "lambda_function_arn" {
   description = "The ARN of the Lambda Function"
-  value       = try(aws_lambda_function.this[0].arn, "")
+  value       = try(local.aws_lambda_function_this[0].arn, "")
 }
 
 output "lambda_function_arn_static" {
@@ -11,57 +11,57 @@ output "lambda_function_arn_static" {
 
 output "lambda_function_invoke_arn" {
   description = "The Invoke ARN of the Lambda Function"
-  value       = try(aws_lambda_function.this[0].invoke_arn, "")
+  value       = try(local.aws_lambda_function_this[0].invoke_arn, "")
 }
 
 output "lambda_function_name" {
   description = "The name of the Lambda Function"
-  value       = try(aws_lambda_function.this[0].function_name, "")
+  value       = try(local.aws_lambda_function_this[0].function_name, "")
 }
 
 output "lambda_function_qualified_arn" {
   description = "The ARN identifying your Lambda Function Version"
-  value       = try(aws_lambda_function.this[0].qualified_arn, "")
+  value       = try(local.aws_lambda_function_this[0].qualified_arn, "")
 }
 
 output "lambda_function_qualified_invoke_arn" {
   description = "The Invoke ARN identifying your Lambda Function Version"
-  value       = try(aws_lambda_function.this[0].qualified_invoke_arn, "")
+  value       = try(local.aws_lambda_function_this[0].qualified_invoke_arn, "")
 }
 
 output "lambda_function_version" {
   description = "Latest published version of Lambda Function"
-  value       = try(aws_lambda_function.this[0].version, "")
+  value       = try(local.aws_lambda_function_this[0].version, "")
 }
 
 output "lambda_function_last_modified" {
   description = "The date Lambda Function resource was last modified"
-  value       = try(aws_lambda_function.this[0].last_modified, "")
+  value       = try(local.aws_lambda_function_this[0].last_modified, "")
 }
 
 output "lambda_function_kms_key_arn" {
   description = "The ARN for the KMS encryption key of Lambda Function"
-  value       = try(aws_lambda_function.this[0].kms_key_arn, "")
+  value       = try(local.aws_lambda_function_this[0].kms_key_arn, "")
 }
 
 output "lambda_function_source_code_hash" {
   description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
-  value       = try(aws_lambda_function.this[0].source_code_hash, "")
+  value       = try(local.aws_lambda_function_this[0].source_code_hash, "")
 }
 
 output "lambda_function_source_code_size" {
   description = "The size in bytes of the function .zip file"
-  value       = try(aws_lambda_function.this[0].source_code_size, "")
+  value       = try(local.aws_lambda_function_this[0].source_code_size, "")
 }
 
 output "lambda_function_signing_job_arn" {
   description = "ARN of the signing job"
-  value       = try(aws_lambda_function.this[0].signing_job_arn, "")
+  value       = try(local.aws_lambda_function_this[0].signing_job_arn, "")
 }
 
 output "lambda_function_signing_profile_version_arn" {
   description = "ARN of the signing profile version"
-  value       = try(aws_lambda_function.this[0].signing_profile_version_arn, "")
+  value       = try(local.aws_lambda_function_this[0].signing_profile_version_arn, "")
 }
 
 # Lambda Function URL

--- a/variables.tf
+++ b/variables.tf
@@ -212,6 +212,12 @@ variable "image_uri" {
   default     = null
 }
 
+variable "ignore_image_uri" {
+  description = "Whether to ignore changes to the image_uri attribute. Set to true if you manage infrastructure and code deployments separately."
+  type        = bool
+  default     = false
+}
+
 variable "image_config_entry_point" {
   description = "The ENTRYPOINT for the docker image"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -212,7 +212,7 @@ variable "image_uri" {
   default     = null
 }
 
-variable "ignore_image_uri" {
+variable "ignore_image_uri_changes" {
   description = "Whether to ignore changes to the image_uri attribute. Set to true if you manage infrastructure and code deployments separately."
   type        = bool
   default     = false

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -60,7 +60,7 @@ module "wrapper" {
   function_tags                                = try(each.value.function_tags, var.defaults.function_tags, {})
   handler                                      = try(each.value.handler, var.defaults.handler, "")
   hash_extra                                   = try(each.value.hash_extra, var.defaults.hash_extra, "")
-  ignore_image_uri                             = try(each.value.ignore_image_uri, var.defaults.ignore_image_uri, false)
+  ignore_image_uri_changes                     = try(each.value.ignore_image_uri_changes, var.defaults.ignore_image_uri_changes, false)
   ignore_source_code_hash                      = try(each.value.ignore_source_code_hash, var.defaults.ignore_source_code_hash, false)
   image_config_command                         = try(each.value.image_config_command, var.defaults.image_config_command, [])
   image_config_entry_point                     = try(each.value.image_config_entry_point, var.defaults.image_config_entry_point, [])

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -60,6 +60,7 @@ module "wrapper" {
   function_tags                                = try(each.value.function_tags, var.defaults.function_tags, {})
   handler                                      = try(each.value.handler, var.defaults.handler, "")
   hash_extra                                   = try(each.value.hash_extra, var.defaults.hash_extra, "")
+  ignore_image_uri                             = try(each.value.ignore_image_uri, var.defaults.ignore_image_uri, false)
   ignore_source_code_hash                      = try(each.value.ignore_source_code_hash, var.defaults.ignore_source_code_hash, false)
   image_config_command                         = try(each.value.image_config_command, var.defaults.image_config_command, [])
   image_config_entry_point                     = try(each.value.image_config_entry_point, var.defaults.image_config_entry_point, [])


### PR DESCRIPTION
## Description
Allow to a rollout the image_uri (from a different place, e.g: Jenkins, GitHub Actions, etc) without requiring you to update the terraform code.

Unfortunately, I don't think there is a way to parametrize the ignore_changes field. Though, I wrote a feature request to opentofu to try to address this:
* https://github.com/opentofu/opentofu/issues/1432

## Motivation and Context
I want to create the lambda so that it targets to `latest` tag by default and I have always something that runs. However, when I make a change that only concerns to the code, I don't need to run terraform (which has all the dependencies for the lambda). I just want to change the image_uri to target the newly created image (even with aws-cli).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
