### PR TITLE
fix: AttributeError os.exists is not valid python attribute.

### DIFF
--- a/package.py
+++ b/package.py
@@ -314,7 +314,7 @@ class ZipWriteStream:
     def close(self, failed=False):
         self._zip.close()
         self._zip = None
-        if not os.exists(self._tmp_filename):
+        if not os.path.exists(self._tmp_filename):
             return
         if failed:
             os.unlink(self._tmp_filename)


### PR DESCRIPTION
## Description
Fixed an attribute error made by typo

## Motivation and Context
This is an error - should be fixed

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
