### PR TITLE
fix(dev): Add pre-commit hook for semantic commit message check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
+default_install_hook_types: [commit-msg, pre-commit]
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.88.4
     hooks:
       - id: terraform_fmt
+        stages: [pre-commit]
       - id: terraform_wrapper_module_for_each
+        stages: [pre-commit]
       - id: terraform_docs
+        stages: [pre-commit]
         args:
           - "--args=--lockfile=false"
       - id: terraform_tflint
+        stages: [pre-commit]
         args:
           - "--args=--only=terraform_deprecated_interpolation"
           - "--args=--only=terraform_deprecated_index"
@@ -23,9 +28,19 @@ repos:
           - "--args=--only=terraform_standard_module_structure"
           - "--args=--only=terraform_workspace_remote"
       - id: terraform_validate
+        stages: [pre-commit]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: check-merge-conflict
+        stages: [pre-commit]
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: trailing-whitespace
+        stages: [pre-commit]
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.1.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,9 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: [] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]
+        args:
+          - fix
+          - feat
+          - docs
+          - ci
+          - chore


### PR DESCRIPTION
This PR adds a pre-commit check using https://github.com/compilerla/conventional-pre-commit to ensure commit messages are valid.

Example usage:

```
# git commit -m "Fix AttributeError os.exists is not valid python attribute." --allow-empty
Terraform fmt........................................(no files to check)Skipped
Terraform wrapper with for_each in module............(no files to check)Skipped
Terraform docs.......................................(no files to check)Skipped
Terraform validate with tflint.......................(no files to check)Skipped
Terraform validate...................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
trim trailing whitespace.............................(no files to check)Skipped
Conventional Commit......................................................Failed
- hook id: conventional-pre-commit
- exit code: 1

[Bad Commit message] >> Fix AttributeError os.exists is not valid python attribute.

        Your commit message does not follow Conventional Commits formatting
        https://www.conventionalcommits.org/

        Conventional Commits start with one of the below types, followed by a colon,
        followed by the commit subject and an optional body seperated by a blank line:

            fix feat docs ci chore

        Example commit message adding a feature:

            feat: implement new API

        Example commit message fixing an issue:

            fix: remove infinite loop

        Example commit with scope in parentheses after the type for more context:

            fix(account): remove infinite loop

        Example commit with a body:

            fix: remove infinite loop

            Additional information on the issue caused by the infinite loop

```