### PR TITLE
fix: Zip source directory should read from sh_work_dir

### DIFF
--- a/package.py
+++ b/package.py
@@ -916,35 +916,36 @@ class BuildPlanManager:
                             # XXX: timestamp=0 - what actually do with it?
                             zs.write_dirs(rd, prefix=prefix, timestamp=0)
             elif cmd == "sh":
-                r, w = os.pipe()
-                side_ch = os.fdopen(r)
-                path, script = action[1:]
-                script = "{} && pwd >&{}".format(script, w)
-                p = subprocess.Popen(
-                    script,
-                    shell=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    cwd=path,
-                    pass_fds=(w,),
-                )
-
-                os.close(w)
-                sh_work_dir = side_ch.read().strip()
-                p.wait()
-                log.info("WD: %s", sh_work_dir)
-                side_ch.close()
-                call_stdout, call_stderr = p.communicate()
-                exit_code = p.returncode
-                log.info("exit_code: %s", exit_code)
-                if exit_code != 0:
-                    raise RuntimeError(
-                        "Script did not run successfully, exit code {}: {} - {}".format(
-                            exit_code,
-                            call_stdout.decode("utf-8").strip(),
-                            call_stderr.decode("utf-8").strip(),
-                        )
+                with tempfile.NamedTemporaryFile(mode="w+t", delete=True) as temp_file:
+                    path, script = action[1:]
+                    script = f"{script} && pwd >{temp_file.name}"
+                    p = subprocess.Popen(
+                        script,
+                        shell=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        cwd=path,
                     )
+
+                    p.wait()
+                    temp_file.seek(0)
+
+                    # NOTE: This var `sh_work_dir` is consumed in cmd == "zip" loop
+                    sh_work_dir = temp_file.read().strip()
+
+                    log.info("WD: %s", sh_work_dir)
+
+                    call_stdout, call_stderr = p.communicate()
+                    exit_code = p.returncode
+                    log.info("exit_code: %s", exit_code)
+                    if exit_code != 0:
+                        raise RuntimeError(
+                            "Script did not run successfully, exit code {}: {} - {}".format(
+                                exit_code,
+                                call_stdout.decode("utf-8").strip(),
+                                call_stderr.decode("utf-8").strip(),
+                            )
+                        )
             elif cmd == "set:filter":
                 patterns = action[1]
                 pf = ZipContentFilter(args=self._args)

--- a/package.py
+++ b/package.py
@@ -918,6 +918,7 @@ class BuildPlanManager:
             elif cmd == "sh":
                 with tempfile.NamedTemporaryFile(mode="w+t", delete=True) as temp_file:
                     path, script = action[1:]
+                    # NOTE: Execute `pwd` to determine the subprocess shell's working directory after having executed all other commands.
                     script = f"{script} && pwd >{temp_file.name}"
                     p = subprocess.Popen(
                         script,

--- a/tests/test_package_toml.py
+++ b/tests/test_package_toml.py
@@ -1,7 +1,6 @@
-import os
 from package import get_build_system_from_pyproject_toml, BuildPlanManager
 from pytest import raises
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 
 def test_get_build_system_from_pyproject_toml_inexistent():
@@ -40,47 +39,3 @@ def test_get_build_system_from_pyproject_toml_poetry():
         )
         == "poetry"
     )
-
-
-def test_zip_source_path_sh_work_dir():
-    zs = Mock()
-    zs.write_dirs = MagicMock()
-
-    bpm = BuildPlanManager(args=Mock())
-    bpm._zip_write_with_filter = MagicMock()
-
-    bpm.execute(
-        build_plan=[
-            ["sh", ".", "cd $(mktemp -d)\n echo pip install"],
-            ["zip:embedded", ".", "./python"],
-        ],
-        zip_stream=zs,
-        query=None,
-    )
-
-    zs.write_dirs.assert_called_once()
-
-    zip_source_path = zs.write_dirs.call_args_list[0][0][0]
-    assert zip_source_path != f"{os.getcwd()}"
-
-
-def test_zip_source_path():
-    zs = Mock()
-    zs.write_dirs = MagicMock()
-
-    bpm = BuildPlanManager(args=Mock())
-    bpm._zip_write_with_filter = MagicMock()
-
-    bpm.execute(
-        build_plan=[
-            ["sh", ".", "echo pip install"],
-            ["zip:embedded", ".", "./python"],
-        ],
-        zip_stream=zs,
-        query=None,
-    )
-
-    zs.write_dirs.assert_called_once()
-
-    zip_source_path = zs.write_dirs.call_args_list[0][0][0]
-    assert zip_source_path == f"{os.getcwd()}"

--- a/tests/test_package_toml.py
+++ b/tests/test_package_toml.py
@@ -1,6 +1,7 @@
+import os
 from package import get_build_system_from_pyproject_toml, BuildPlanManager
 from pytest import raises
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 
 def test_get_build_system_from_pyproject_toml_inexistent():
@@ -39,3 +40,47 @@ def test_get_build_system_from_pyproject_toml_poetry():
         )
         == "poetry"
     )
+
+
+def test_zip_source_path_sh_work_dir():
+    zs = Mock()
+    zs.write_dirs = MagicMock()
+
+    bpm = BuildPlanManager(args=Mock())
+    bpm._zip_write_with_filter = MagicMock()
+
+    bpm.execute(
+        build_plan=[
+            ["sh", ".", "cd $(mktemp -d)\n echo pip install"],
+            ["zip:embedded", ".", "./python"],
+        ],
+        zip_stream=zs,
+        query=None,
+    )
+
+    zs.write_dirs.assert_called_once()
+
+    zip_source_path = zs.write_dirs.call_args_list[0][0][0]
+    assert zip_source_path != f"{os.getcwd()}"
+
+
+def test_zip_source_path():
+    zs = Mock()
+    zs.write_dirs = MagicMock()
+
+    bpm = BuildPlanManager(args=Mock())
+    bpm._zip_write_with_filter = MagicMock()
+
+    bpm.execute(
+        build_plan=[
+            ["sh", ".", "echo pip install"],
+            ["zip:embedded", ".", "./python"],
+        ],
+        zip_stream=zs,
+        query=None,
+    )
+
+    zs.write_dirs.assert_called_once()
+
+    zip_source_path = zs.write_dirs.call_args_list[0][0][0]
+    assert zip_source_path == f"{os.getcwd()}"

--- a/tests/test_zip_source.py
+++ b/tests/test_zip_source.py
@@ -1,0 +1,46 @@
+import os
+from unittest.mock import MagicMock, Mock
+
+from package import BuildPlanManager
+
+
+def test_zip_source_path_sh_work_dir():
+    zs = Mock()
+    zs.write_dirs = MagicMock()
+
+    bpm = BuildPlanManager(args=Mock())
+
+    bpm.execute(
+        build_plan=[
+            ["sh", ".", "cd $(mktemp -d)\n echo pip install"],
+            ["zip:embedded", ".", "./python"],
+        ],
+        zip_stream=zs,
+        query=None,
+    )
+
+    zs.write_dirs.assert_called_once()
+
+    zip_source_path = zs.write_dirs.call_args_list[0][0][0]
+    assert zip_source_path != f"{os.getcwd()}"
+
+
+def test_zip_source_path():
+    zs = Mock()
+    zs.write_dirs = MagicMock()
+
+    bpm = BuildPlanManager(args=Mock())
+
+    bpm.execute(
+        build_plan=[
+            ["sh", ".", "echo pip install"],
+            ["zip:embedded", ".", "./python"],
+        ],
+        zip_stream=zs,
+        query=None,
+    )
+
+    zs.write_dirs.assert_called_once()
+
+    zip_source_path = zs.write_dirs.call_args_list[0][0][0]
+    assert zip_source_path == f"{os.getcwd()}"


### PR DESCRIPTION
fixes #557 

## Description

adding back the  declaration of `sh_work_dir` that was removed in #534 because the variable is required and consumed [here](https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/2202912af9c6e02313e24bd15e3923079addeedc/package.py#L881)




Also, had to refactor to write to a tempfile instead of using the fd 


because in systems where `/bin/sh` -> `/bin/dash`,  it would throw the following error
![image](https://github.com/terraform-aws-modules/terraform-aws-lambda/assets/28011783/94903ba2-b147-4cc7-9a0d-09855a56734c)

