### PR TITLE
feat: Added create before destroy on aws_lambda_permission

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -273,13 +273,17 @@ resource "aws_lambda_permission" "current_version_triggers" {
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
 
-  statement_id       = try(each.value.statement_id, each.key)
-  action             = try(each.value.action, "lambda:InvokeFunction")
-  principal          = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
-  principal_org_id   = try(each.value.principal_org_id, null)
-  source_arn         = try(each.value.source_arn, null)
-  source_account     = try(each.value.source_account, null)
-  event_source_token = try(each.value.event_source_token, null)
+  statement_id_prefix = try(each.value.statement_id, each.key)
+  action              = try(each.value.action, "lambda:InvokeFunction")
+  principal           = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  principal_org_id    = try(each.value.principal_org_id, null)
+  source_arn          = try(each.value.source_arn, null)
+  source_account      = try(each.value.source_account, null)
+  event_source_token  = try(each.value.event_source_token, null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Error: Error adding new Lambda Permission for lambda: InvalidParameterValueException: We currently do not support adding policies for $LATEST.
@@ -288,13 +292,17 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 
   function_name = aws_lambda_function.this[0].function_name
 
-  statement_id       = try(each.value.statement_id, each.key)
-  action             = try(each.value.action, "lambda:InvokeFunction")
-  principal          = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
-  principal_org_id   = try(each.value.principal_org_id, null)
-  source_arn         = try(each.value.source_arn, null)
-  source_account     = try(each.value.source_account, null)
-  event_source_token = try(each.value.event_source_token, null)
+  statement_id_prefix = try(each.value.statement_id, each.key)
+  action              = try(each.value.action, "lambda:InvokeFunction")
+  principal           = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  principal_org_id    = try(each.value.principal_org_id, null)
+  source_arn          = try(each.value.source_arn, null)
+  source_account      = try(each.value.source_account, null)
+  event_source_token  = try(each.value.event_source_token, null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "this" {


### PR DESCRIPTION
## Description

Update lambda permissions handling so there's no interruption to the permissions available to a lambda.

The change keeps the module interface the same and so there's no changes needed to the documentation.

The only material change visible to users is that the statement_id will now be used as a prefix rather than as a specific value.

## Motivation and Context

When any parameters contain dynamic elements, e.g. `data.aws_region.name`, and that is evaluated in an intermediate module, it is not known until apply time, which causes the permission to he removed and added.  During this window, Cloudwatch Logs will see errors when delivering events to the subscription and stop sending events for 10 minutes.

By switching to a statement_id_prefix and using a create_before_destroy lifecycle we avoid such interruptions.

## Breaking Changes

No breaking changes.

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
  - No updates needed
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - tested with `examples/alias` which is confirmed to use both `module.lambda_function.aws_lambda_permission.unqualified_alias_triggers["APIGatewayAny"]` and `module.lambda_function.aws_lambda_permission.current_version_triggers["APIGatewayAny"]`
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

This has been tested via our own module that in turn calls this module.  Prior to this change we saw the terraform traces showing a remove operation followed by an add operation on the lambda permissions.  After this change a new lambda permission is created first, followed by removal of the old permission.