### PR TITLE
fix: Issues with content filtering when using patterns

### DIFF
--- a/tests/test_zip_source.py
+++ b/tests/test_zip_source.py
@@ -1,7 +1,10 @@
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, Mock
 
-from package import BuildPlanManager
+import pytest
+
+from package import BuildPlanManager, ZipContentFilter, datatree
 
 
 def test_zip_source_path_sh_work_dir():
@@ -44,3 +47,75 @@ def test_zip_source_path():
 
     zip_source_path = zs.write_dirs.call_args_list[0][0][0]
     assert zip_source_path == f"{os.getcwd()}"
+
+
+@pytest.fixture
+def source_path(tmp_path: str) -> Path:
+    """Creates a tmp stage dir for running tests."""
+    tmp_path = Path(tmp_path)
+    source = tmp_path / "some_dir"
+    source.mkdir()
+    for files in ["file.py", "file2.py", "README.md", "requirements.txt"]:
+        (source / files).touch()
+    yield source
+
+
+def test_zip_content_filter(source_path: Path):
+    """Test the zip content filter does not take all positive."""
+    args = Mock()
+    query_data = {
+        "runtime": "python",
+        "source_path": {
+            "path": str(source_path),
+            "patterns": [".*.py$"],
+        },
+    }
+    query = datatree("prepare_query", **query_data)
+
+    file_filter = ZipContentFilter(args=args)
+    file_filter.compile(query.source_path.patterns)
+    filtered = list(file_filter.filter(query.source_path.path))
+    expected = [str(source_path / fname) for fname in ["file.py", "file2.py"]]
+    assert filtered == sorted(expected)
+
+    # Test that filtering with empty patterns returns all files.
+    file_filter = ZipContentFilter(args=args)
+    file_filter.compile([])
+    filtered = list(file_filter.filter(query.source_path.path))
+    expected = [
+        str(source_path / fname)
+        for fname in ["file.py", "file2.py", "README.md", "requirements.txt"]
+    ]
+    assert filtered == sorted(expected)
+
+
+def test_generate_hash(source_path: Path):
+    """Tests prepare hash generation and also packaging."""
+    args = Mock()
+
+    query_data = {
+        "runtime": "python",
+        "source_path": {
+            "path": str(source_path),
+            "patterns": ["!.*", ".*.py$"],
+        },
+    }
+    query = datatree("prepare_query", **query_data)
+
+    bpm = BuildPlanManager(args)
+    bpm.plan(query.source_path, query)
+    hash1 = bpm.hash([]).hexdigest()
+
+    # Add a new file that does not match the pattern.
+    (source_path / "file3.pyc").touch()
+    bpm.plan(query.source_path, query)
+    hash2 = bpm.hash([]).hexdigest()
+    # Both hashes should still be the same.
+    assert hash1 == hash2
+
+    # Add a new file that does match the pattern.
+    (source_path / "file4.py").touch()
+    bpm.plan(query.source_path, query)
+    hash3 = bpm.hash([]).hexdigest()
+    # Hash should be different.
+    assert hash1 != hash3


### PR DESCRIPTION
## Description
-- `ZipContentFilter` logic for patterns that have a single allowed pattern.
   Earlier this would include all files.
-- `generate_content_hash` also considers the patterns before generating the
   hash so that the hash generated matches the content of the zip.


## Motivation and Context

- Without using this patch deployments to the same environment from different machines with intermediaries such as __pycache__ cause redeployments.
- This also fixes the surprising behaviour that a pattern of `[ ".*.py$" ]` will also include files that do not match that pattern.

## Breaking Changes

Unless someone is relying on the legacy behaviour this should not be a breaking change. It will however cause redeployments because of content hash changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
