### PR TITLE
feat: Added support for alias to have multiple filter criteria same as function

### DIFF
--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -167,8 +167,12 @@ resource "aws_lambda_event_source_mapping" "this" {
     for_each = try(each.value.filter_criteria, null) != null ? [true] : []
 
     content {
-      filter {
-        pattern = try(each.value["filter_criteria"].pattern, null)
+      dynamic "filter" {
+        for_each = try(flatten([each.value.filter_criteria]), [])
+
+        content {
+          pattern = try(filter.value.pattern, null)
+        }
       }
     }
   }


### PR DESCRIPTION
… event source mappings, same as lambda function

## Description
I have added support in the alias submodule to have multiple event source mapping `filter_criteria` in line with the main lambda function.

## Motivation and Context
I have wasted an entire evening trying to make event source mapping filter_criteria work on the alias with 

`operation error Lambda: CreateEventSourceMapping, https response error StatusCode: 400, RequestID: 4d25b930-c830-49e2-bbc7-dbd4add503f7, InvalidParameterValueException: Invalid filter pattern definition`. 

This is based on the example found [here](https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/v7.6.0/examples/event-source-mapping/main.tf)

## Breaking Changes
Alias will be in line with the existing documentation.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
