### PR TITLE
fix: Always use absolute path to temp folders

### DIFF
--- a/package.py
+++ b/package.py
@@ -124,11 +124,12 @@ def tempdir(dir=None):
     """Creates a temporary directory and then deletes it afterwards."""
     prefix = "terraform-aws-lambda-"
     path = tempfile.mkdtemp(prefix=prefix, dir=dir)
-    cmd_log.info("mktemp -d %sXXXXXXXX # %s", prefix, shlex.quote(path))
+    abs_path = os.path.abspath(path)
+    cmd_log.info("mktemp -d %sXXXXXXXX # %s", prefix, shlex.quote(abs_path))
     try:
-        yield path
+        yield abs_path
     finally:
-        shutil.rmtree(path)
+        shutil.rmtree(abs_path)
 
 
 def list_files(top_path, log=None):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixes #592.

Since Python 3.12 changed the default behavior of `tempfile.mkdtemp(suffix=None, prefix=None, dir=None)` (see the documentation [here](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp)) and based on the discussion in the issue, it is recommended to use absolute paths for temporary folders. This pull request addresses that for earlier Python versions.

From now on, the method in the [package.py](https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/b88a85627c84a4e9d1ad2a655455d10b386bc63f/package.py#L123) will return an absolute path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The details are described in issue #592. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

Since this is the proposed solution and all the examples use absolute paths for the temporary folders, it is presumably not a breaking change.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
