### PR TITLE
feat: Added the skip_destroy argument for functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.91.0
+    rev: v1.92.2
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -855,6 +855,7 @@ No modules.
 | <a name="input_s3_object_tags_only"></a> [s3\_object\_tags\_only](#input\_s3\_object\_tags\_only) | Set to true to not merge tags with s3\_object\_tags. Useful to avoid breaching S3 Object 10 tag limit. | `bool` | `false` | no |
 | <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | Directory name where artifacts should be stored in the S3 bucket. If unset, the path from `artifacts_dir` is used | `string` | `null` | no |
 | <a name="input_s3_server_side_encryption"></a> [s3\_server\_side\_encryption](#input\_s3\_server\_side\_encryption) | Specifies server-side encryption of the object in S3. Valid values are "AES256" and "aws:kms". | `string` | `null` | no |
+| <a name="input_skip_destroy"></a> [skip\_destroy](#input\_skip\_destroy) | Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state. Useful for Lambda@Edge functions attached to CloudFront distributions. | `bool` | `null` | no |
 | <a name="input_snap_start"></a> [snap\_start](#input\_snap\_start) | (Optional) Snap start settings for low-latency startups | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `any` | `null` | no |
 | <a name="input_store_on_s3"></a> [store\_on\_s3](#input\_store\_on\_s3) | Whether to store produced artifacts on S3 or locally. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "this" {
   code_signing_config_arn            = var.code_signing_config_arn
   replace_security_groups_on_destroy = var.replace_security_groups_on_destroy
   replacement_security_group_ids     = var.replacement_security_group_ids
-  skip_destroy                       = var.lambda_skip_destroy
+  skip_destroy                       = var.skip_destroy
 
   /* ephemeral_storage is not supported in gov-cloud region, so it should be set to `null` */
   dynamic "ephemeral_storage" {

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "aws_lambda_function" "this" {
   code_signing_config_arn            = var.code_signing_config_arn
   replace_security_groups_on_destroy = var.replace_security_groups_on_destroy
   replacement_security_group_ids     = var.replacement_security_group_ids
+  skip_destroy                       = var.lambda_skip_destroy
 
   /* ephemeral_storage is not supported in gov-cloud region, so it should be set to `null` */
   dynamic "ephemeral_storage" {

--- a/variables.tf
+++ b/variables.tf
@@ -254,8 +254,8 @@ variable "timeouts" {
   default     = {}
 }
 
-variable "lambda_skip_destroy" {
-  description = "(Optional) Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state."
+variable "skip_destroy" {
+  description = "Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state. Useful for Lambda@Edge functions attached to CloudFront distributions."
   type        = bool
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -254,6 +254,12 @@ variable "timeouts" {
   default     = {}
 }
 
+variable "lambda_skip_destroy" {
+  description = "(Optional) Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state."
+  type        = bool
+  default     = null
+}
+
 ###############
 # Function URL
 ###############

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -119,6 +119,7 @@ module "wrapper" {
   s3_object_tags_only                          = try(each.value.s3_object_tags_only, var.defaults.s3_object_tags_only, false)
   s3_prefix                                    = try(each.value.s3_prefix, var.defaults.s3_prefix, null)
   s3_server_side_encryption                    = try(each.value.s3_server_side_encryption, var.defaults.s3_server_side_encryption, null)
+  skip_destroy                                 = try(each.value.skip_destroy, var.defaults.skip_destroy, null)
   snap_start                                   = try(each.value.snap_start, var.defaults.snap_start, false)
   source_path                                  = try(each.value.source_path, var.defaults.source_path, null)
   store_on_s3                                  = try(each.value.store_on_s3, var.defaults.store_on_s3, false)


### PR DESCRIPTION
## Description
Added the "skip_destroy" argument for the "function" resource. 
More info from the AWS Provider Doc:
(Optional) Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state.

## Motivation and Context
Particularly useful for Lambda@Edge that cannot be destroyed if they are still associated with a CloudFront Distribution.  


