### PR TITLE
Fix: error checking for incompatible variables create_role and lambda_role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,16 @@ locals {
 }
 
 resource "aws_lambda_function" "this" {
+
+  lifecycle {
+    precondition {
+      condition     = var.create_role && var.lambda_role != []
+      error_message = "The 'create_role' and 'lambda_role' variables should not be used together. When creating a role, use 'role_name' to set the name."
+      # The lambda_role variable should only be used to attach a pre-existing role, and will do nothing
+      #    if create_role is true.
+    }
+  }
+
   count = local.create && var.create_function && !var.create_layer ? 1 : 0
 
   function_name                      = var.function_name

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "this" {
 
   lifecycle {
     precondition {
-      condition     = var.create_role && var.lambda_role != []
+      condition     = !var.create_role || var.create_role && var.lambda_role == ""
       error_message = "The 'create_role' and 'lambda_role' variables should not be used together. When creating a role, use 'role_name' to set the name."
       # The lambda_role variable should only be used to attach a pre-existing role, and will do nothing
       #    if create_role is true.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

There is an undocumented conflict between create_role and lambda_role. The latter is completely ignored if the former is set to true, and instead either the role_name variable or the function name is used. This creates confusing behavior for users, and is exacerbated because it will fail silently. This error checking tests whether create_role is true, and passes if it is false or if it is true but lambda_role is empty.