### PR TITLE
feat: Add support for kafka event source config

### DIFF
--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -161,7 +161,7 @@ resource "aws_lambda_event_source_mapping" "this" {
       consumer_group_id = self_managed_kafka_event_source_config.value.consumer_group_id
     }
   }
-  
+
   dynamic "amazon_managed_kafka_event_source_config" {
     for_each = try(each.value.amazon_managed_kafka_event_source_config, [])
     content {

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -155,6 +155,20 @@ resource "aws_lambda_event_source_mapping" "this" {
     }
   }
 
+  dynamic "self_managed_kafka_event_source_config" {
+    for_each = try(each.value.self_managed_kafka_event_source_config, [])
+    content {
+      consumer_group_id = self_managed_kafka_event_source_config.value.consumer_group_id
+    }
+  }
+  
+  dynamic "amazon_managed_kafka_event_source_config" {
+    for_each = try(each.value.amazon_managed_kafka_event_source_config, [])
+    content {
+      consumer_group_id = amazon_managed_kafka_event_source_config.value.consumer_group_id
+    }
+  }
+
   dynamic "source_access_configuration" {
     for_each = try(each.value.source_access_configuration, [])
     content {

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -158,14 +158,14 @@ resource "aws_lambda_event_source_mapping" "this" {
   dynamic "self_managed_kafka_event_source_config" {
     for_each = try(each.value.self_managed_kafka_event_source_config, [])
     content {
-      consumer_group_id = self_managed_kafka_event_source_config.value.consumer_group_id
+      consumer_group_id = try(self_managed_kafka_event_source_config.value.consumer_group_id, null)
     }
   }
 
   dynamic "amazon_managed_kafka_event_source_config" {
     for_each = try(each.value.amazon_managed_kafka_event_source_config, [])
     content {
-      consumer_group_id = amazon_managed_kafka_event_source_config.value.consumer_group_id
+      consumer_group_id = try(amazon_managed_kafka_event_source_config.value.consumer_group_id, null)
     }
   }
 


### PR DESCRIPTION
## Description
Add support for `self_managed_kafka_event_source_config` and `amazon_managed_kafka_event_source_config` to be able to set custom consumer group ids.

## Motivation and Context
This config is available in lambda function and should be available in alias as well so we can specify custom consumer group ids.
