### PR TITLE
fix: Rename npm_package_json to npm_requirements

### DIFF
--- a/package.py
+++ b/package.py
@@ -821,7 +821,9 @@ class BuildPlanManager:
                     pip_requirements = claim.get("pip_requirements")
                     poetry_install = claim.get("poetry_install")
                     poetry_export_extra_args = claim.get("poetry_export_extra_args", [])
-                    npm_requirements = claim.get("npm_package_json")
+                    npm_requirements = claim.get(
+                        "npm_requirements", claim.get("npm_package_json")
+                    )
                     runtime = claim.get("runtime", query.runtime)
 
                     if pip_requirements and runtime.startswith("python"):


### PR DESCRIPTION
## Description
This change was missed in https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/293. Documentation is up to date, code is not.

Fixes https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/506
Replace https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/507

## Motivation and Context

This would solve inconsistencies in the documentation. It says the field is named `npm_requirements`, but it's in fact `npm_package_json`.

## Breaking Changes
There is no breaking change. The wrongly documented field `npm_requirements` will start to work as expected. The previous non-documented field `npm_package_json` will keep working.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
