### PR TITLE
feat: Ignore last_modified on aws_lambda_function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
+        args:
+          - "--args=--module-repo-org=gametimesf"
+          - "--args=--module-repo-shortname=tf-aws-lambda"
       - id: terraform_docs
         args:
           - "--args=--lockfile=false"

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,6 @@ resource "aws_lambda_function" "this" {
   }
 
   tags = merge(
-    { terraform-aws-modules = "lambda" },
     var.tags,
     var.function_tags
   )
@@ -164,6 +163,10 @@ resource "aws_lambda_function" "this" {
     aws_iam_role_policy_attachment.vpc,
     aws_iam_role_policy_attachment.tracing,
   ]
+
+  lifecycle {
+    ignore_changes = [last_modified]
+  }
 }
 
 resource "aws_lambda_layer_version" "this" {

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -12,9 +12,9 @@ This wrapper does not implement any extra functionality.
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/lambda/aws//wrappers"
+  source = "tfr:///gametimesf/tf-aws-lambda/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lambda.git//wrappers?ref=master"
+  # source = "git::git@github.com:gametimesf/terraform-aws-tf-aws-lambda.git//wrappers?ref=master"
 }
 
 inputs = {
@@ -42,7 +42,7 @@ inputs = {
 
 ```hcl
 module "wrapper" {
-  source = "terraform-aws-modules/lambda/aws//wrappers"
+  source = "gametimesf/tf-aws-lambda/aws//wrappers"
 
   defaults = { # Default values
     create = true

--- a/wrappers/alias/README.md
+++ b/wrappers/alias/README.md
@@ -12,9 +12,9 @@ This wrapper does not implement any extra functionality.
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/lambda/aws//wrappers/alias"
+  source = "tfr:///gametimesf/tf-aws-lambda/aws//wrappers/alias"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lambda.git//wrappers/alias?ref=master"
+  # source = "git::git@github.com:gametimesf/terraform-aws-tf-aws-lambda.git//wrappers/alias?ref=master"
 }
 
 inputs = {
@@ -42,7 +42,7 @@ inputs = {
 
 ```hcl
 module "wrapper" {
-  source = "terraform-aws-modules/lambda/aws//wrappers/alias"
+  source = "gametimesf/tf-aws-lambda/aws//wrappers/alias"
 
   defaults = { # Default values
     create = true

--- a/wrappers/deploy/README.md
+++ b/wrappers/deploy/README.md
@@ -12,9 +12,9 @@ This wrapper does not implement any extra functionality.
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/lambda/aws//wrappers/deploy"
+  source = "tfr:///gametimesf/tf-aws-lambda/aws//wrappers/deploy"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lambda.git//wrappers/deploy?ref=master"
+  # source = "git::git@github.com:gametimesf/terraform-aws-tf-aws-lambda.git//wrappers/deploy?ref=master"
 }
 
 inputs = {
@@ -42,7 +42,7 @@ inputs = {
 
 ```hcl
 module "wrapper" {
-  source = "terraform-aws-modules/lambda/aws//wrappers/deploy"
+  source = "gametimesf/tf-aws-lambda/aws//wrappers/deploy"
 
   defaults = { # Default values
     create = true

--- a/wrappers/docker-build/README.md
+++ b/wrappers/docker-build/README.md
@@ -12,9 +12,9 @@ This wrapper does not implement any extra functionality.
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/lambda/aws//wrappers/docker-build"
+  source = "tfr:///gametimesf/tf-aws-lambda/aws//wrappers/docker-build"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lambda.git//wrappers/docker-build?ref=master"
+  # source = "git::git@github.com:gametimesf/terraform-aws-tf-aws-lambda.git//wrappers/docker-build?ref=master"
 }
 
 inputs = {
@@ -42,7 +42,7 @@ inputs = {
 
 ```hcl
 module "wrapper" {
-  source = "terraform-aws-modules/lambda/aws//wrappers/docker-build"
+  source = "gametimesf/tf-aws-lambda/aws//wrappers/docker-build"
 
   defaults = { # Default values
     create = true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds the lifecycle ignore rule to the lambda function. Without this, it will prompt to re-deploy the lambda function anytime a plan/apply is performed (even without a change to the underlying src files). The behavior now is that it'll only trigger a re-deploy if the src code or the module call is changed.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A nothing is using this yet. Will be the first addition to the new release.

## How Has This Been Tested?
I verified this locally, was able to do multiple plan/applies on a project without it wanting to update the lambda resource.
