### PR TITLE
feat: Add function_url_auth_type option to aws_lambda_permission

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -280,13 +280,14 @@ resource "aws_lambda_permission" "current_version_triggers" {
   function_name = aws_lambda_function.this[0].function_name
   qualifier     = aws_lambda_function.this[0].version
 
-  statement_id_prefix = try(each.value.statement_id, each.key)
-  action              = try(each.value.action, "lambda:InvokeFunction")
-  principal           = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
-  principal_org_id    = try(each.value.principal_org_id, null)
-  source_arn          = try(each.value.source_arn, null)
-  source_account      = try(each.value.source_account, null)
-  event_source_token  = try(each.value.event_source_token, null)
+  statement_id_prefix    = try(each.value.statement_id, each.key)
+  action                 = try(each.value.action, "lambda:InvokeFunction")
+  principal              = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  principal_org_id       = try(each.value.principal_org_id, null)
+  source_arn             = try(each.value.source_arn, null)
+  source_account         = try(each.value.source_account, null)
+  event_source_token     = try(each.value.event_source_token, null)
+  function_url_auth_type = try(each.value.function_url_auth_type, null)
 
   lifecycle {
     create_before_destroy = true
@@ -299,13 +300,14 @@ resource "aws_lambda_permission" "unqualified_alias_triggers" {
 
   function_name = aws_lambda_function.this[0].function_name
 
-  statement_id_prefix = try(each.value.statement_id, each.key)
-  action              = try(each.value.action, "lambda:InvokeFunction")
-  principal           = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
-  principal_org_id    = try(each.value.principal_org_id, null)
-  source_arn          = try(each.value.source_arn, null)
-  source_account      = try(each.value.source_account, null)
-  event_source_token  = try(each.value.event_source_token, null)
+  statement_id_prefix    = try(each.value.statement_id, each.key)
+  action                 = try(each.value.action, "lambda:InvokeFunction")
+  principal              = try(each.value.principal, format("%s.amazonaws.com", try(each.value.service, "")))
+  principal_org_id       = try(each.value.principal_org_id, null)
+  source_arn             = try(each.value.source_arn, null)
+  source_account         = try(each.value.source_account, null)
+  event_source_token     = try(each.value.event_source_token, null)
+  function_url_auth_type = try(each.value.function_url_auth_type, null)
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Description
add `function_url_auth_type` option option to `aws_lambda_permission`

relates to #425 

## Motivation and Context
add cross account permissions

## Breaking Changes
none

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
Applied and tested on forked version
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
