### PR TITLE
feat: Support lambda function `vpc_config.ipv6_allowed_for_dual_stack` and event source mapping `tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
@@ -676,7 +676,7 @@ Q4: What does this error mean - `"We currently do not support adding policies fo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_external"></a> [external](#provider\_external) | >= 1.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
@@ -805,6 +805,7 @@ No modules.
 | <a name="input_image_config_working_directory"></a> [image\_config\_working\_directory](#input\_image\_config\_working\_directory) | The working directory for the docker image | `string` | `null` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The ECR image URI containing the function's deployment package. | `string` | `null` | no |
 | <a name="input_invoke_mode"></a> [invoke\_mode](#input\_invoke\_mode) | Invoke mode of the Lambda Function URL. Valid values are BUFFERED (default) and RESPONSE\_STREAM. | `string` | `null` | no |
+| <a name="input_ipv6_allowed_for_dual_stack"></a> [ipv6\_allowed\_for\_dual\_stack](#input\_ipv6\_allowed\_for\_dual\_stack) | Allows outbound IPv6 traffic on VPC functions that are connected to dual-stack subnets | `bool` | `null` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of KMS key to use by your Lambda Function | `string` | `null` | no |
 | <a name="input_lambda_at_edge"></a> [lambda\_at\_edge](#input\_lambda\_at\_edge) | Set this to true if using Lambda@Edge, to enable publishing, limit the timeout, and allow edgelambda.amazonaws.com to invoke the function | `bool` | `false` | no |
 | <a name="input_lambda_at_edge_logs_all_regions"></a> [lambda\_at\_edge\_logs\_all\_regions](#input\_lambda\_at\_edge\_logs\_all\_regions) | Whether to specify a wildcard in IAM policy used by Lambda@Edge to allow logging in all regions | `bool` | `true` | no |
@@ -876,6 +877,7 @@ No modules.
 |------|-------------|
 | <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
 | <a name="output_lambda_cloudwatch_log_group_name"></a> [lambda\_cloudwatch\_log\_group\_name](#output\_lambda\_cloudwatch\_log\_group\_name) | The name of the Cloudwatch Log Group |
+| <a name="output_lambda_event_source_mapping_arn"></a> [lambda\_event\_source\_mapping\_arn](#output\_lambda\_event\_source\_mapping\_arn) | The event source mapping ARN |
 | <a name="output_lambda_event_source_mapping_function_arn"></a> [lambda\_event\_source\_mapping\_function\_arn](#output\_lambda\_event\_source\_mapping\_function\_arn) | The the ARN of the Lambda function the event source mapping is sending events to |
 | <a name="output_lambda_event_source_mapping_state"></a> [lambda\_event\_source\_mapping\_state](#output\_lambda\_event\_source\_mapping\_state) | The state of the event source mapping |
 | <a name="output_lambda_event_source_mapping_state_transition_reason"></a> [lambda\_event\_source\_mapping\_state\_transition\_reason](#output\_lambda\_event\_source\_mapping\_state\_transition\_reason) | The reason the event source mapping is in its current state |
@@ -896,8 +898,10 @@ No modules.
 | <a name="output_lambda_function_url_id"></a> [lambda\_function\_url\_id](#output\_lambda\_function\_url\_id) | The Lambda Function URL generated id |
 | <a name="output_lambda_function_version"></a> [lambda\_function\_version](#output\_lambda\_function\_version) | Latest published version of Lambda Function |
 | <a name="output_lambda_layer_arn"></a> [lambda\_layer\_arn](#output\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_lambda_layer_code_sha256"></a> [lambda\_layer\_code\_sha256](#output\_lambda\_layer\_code\_sha256) | Base64-encoded representation of raw SHA-256 sum of the zip file |
 | <a name="output_lambda_layer_created_date"></a> [lambda\_layer\_created\_date](#output\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
 | <a name="output_lambda_layer_layer_arn"></a> [lambda\_layer\_layer\_arn](#output\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_lambda_layer_signing_job_arn"></a> [lambda\_layer\_signing\_job\_arn](#output\_lambda\_layer\_signing\_job\_arn) | ARN of a signing job |
 | <a name="output_lambda_layer_source_code_size"></a> [lambda\_layer\_source\_code\_size](#output\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
 | <a name="output_lambda_layer_version"></a> [lambda\_layer\_version](#output\_lambda\_layer\_version) | The Lambda Layer version |
 | <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
@@ -905,6 +909,7 @@ No modules.
 | <a name="output_lambda_role_unique_id"></a> [lambda\_role\_unique\_id](#output\_lambda\_role\_unique\_id) | The unique id of the IAM role created for the Lambda Function |
 | <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
 | <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_signing_profile_version_arn"></a> [signing\_profile\_version\_arn](#output\_signing\_profile\_version\_arn) | ARN for a signing profile version |
 <!-- END_TF_DOCS -->
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -898,11 +898,8 @@ No modules.
 | <a name="output_lambda_function_url_id"></a> [lambda\_function\_url\_id](#output\_lambda\_function\_url\_id) | The Lambda Function URL generated id |
 | <a name="output_lambda_function_version"></a> [lambda\_function\_version](#output\_lambda\_function\_version) | Latest published version of Lambda Function |
 | <a name="output_lambda_layer_arn"></a> [lambda\_layer\_arn](#output\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
-| <a name="output_lambda_layer_code_sha256"></a> [lambda\_layer\_code\_sha256](#output\_lambda\_layer\_code\_sha256) | Base64-encoded representation of raw SHA-256 sum of the zip file |
 | <a name="output_lambda_layer_created_date"></a> [lambda\_layer\_created\_date](#output\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
 | <a name="output_lambda_layer_layer_arn"></a> [lambda\_layer\_layer\_arn](#output\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
-| <a name="output_lambda_layer_signing_job_arn"></a> [lambda\_layer\_signing\_job\_arn](#output\_lambda\_layer\_signing\_job\_arn) | ARN of a signing job |
-| <a name="output_lambda_layer_signing_profile_version_arn"></a> [lambda\_layer\_signing\_profile\_version\_arn](#output\_lambda\_layer\_signing\_profile\_version\_arn) | ARN for a signing profile version |
 | <a name="output_lambda_layer_source_code_size"></a> [lambda\_layer\_source\_code\_size](#output\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
 | <a name="output_lambda_layer_version"></a> [lambda\_layer\_version](#output\_lambda\_layer\_version) | The Lambda Layer version |
 | <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |

--- a/README.md
+++ b/README.md
@@ -902,6 +902,7 @@ No modules.
 | <a name="output_lambda_layer_created_date"></a> [lambda\_layer\_created\_date](#output\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
 | <a name="output_lambda_layer_layer_arn"></a> [lambda\_layer\_layer\_arn](#output\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
 | <a name="output_lambda_layer_signing_job_arn"></a> [lambda\_layer\_signing\_job\_arn](#output\_lambda\_layer\_signing\_job\_arn) | ARN of a signing job |
+| <a name="output_lambda_layer_signing_profile_version_arn"></a> [lambda\_layer\_signing\_profile\_version\_arn](#output\_lambda\_layer\_signing\_profile\_version\_arn) | ARN for a signing profile version |
 | <a name="output_lambda_layer_source_code_size"></a> [lambda\_layer\_source\_code\_size](#output\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
 | <a name="output_lambda_layer_version"></a> [lambda\_layer\_version](#output\_lambda\_layer\_version) | The Lambda Layer version |
 | <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
@@ -909,7 +910,6 @@ No modules.
 | <a name="output_lambda_role_unique_id"></a> [lambda\_role\_unique\_id](#output\_lambda\_role\_unique\_id) | The unique id of the IAM role created for the Lambda Function |
 | <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
 | <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| <a name="output_signing_profile_version_arn"></a> [signing\_profile\_version\_arn](#output\_signing\_profile\_version\_arn) | ARN for a signing profile version |
 <!-- END_TF_DOCS -->
 
 ## Development

--- a/examples/alias/README.md
+++ b/examples/alias/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/alias/versions.tf
+++ b/examples/alias/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/async/versions.tf
+++ b/examples/async/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/build-package/versions.tf
+++ b/examples/build-package/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/code-signing/README.md
+++ b/examples/code-signing/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/code-signing/versions.tf
+++ b/examples/code-signing/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -84,11 +84,8 @@ No inputs.
 | <a name="output_lambda_function_url_id"></a> [lambda\_function\_url\_id](#output\_lambda\_function\_url\_id) | The Lambda Function URL generated id |
 | <a name="output_lambda_function_version"></a> [lambda\_function\_version](#output\_lambda\_function\_version) | Latest published version of Lambda Function |
 | <a name="output_lambda_layer_arn"></a> [lambda\_layer\_arn](#output\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
-| <a name="output_lambda_layer_code_sha256"></a> [lambda\_layer\_code\_sha256](#output\_lambda\_layer\_code\_sha256) | Base64-encoded representation of raw SHA-256 sum of the zip file |
 | <a name="output_lambda_layer_created_date"></a> [lambda\_layer\_created\_date](#output\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
 | <a name="output_lambda_layer_layer_arn"></a> [lambda\_layer\_layer\_arn](#output\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
-| <a name="output_lambda_layer_signing_job_arn"></a> [lambda\_layer\_signing\_job\_arn](#output\_lambda\_layer\_signing\_job\_arn) | ARN of a signing job |
-| <a name="output_lambda_layer_signing_profile_version_arn"></a> [lambda\_layer\_signing\_profile\_version\_arn](#output\_lambda\_layer\_signing\_profile\_version\_arn) | ARN for a signing profile version |
 | <a name="output_lambda_layer_source_code_size"></a> [lambda\_layer\_source\_code\_size](#output\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
 | <a name="output_lambda_layer_version"></a> [lambda\_layer\_version](#output\_lambda\_layer\_version) | The Lambda Layer version |
 | <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -84,8 +84,11 @@ No inputs.
 | <a name="output_lambda_function_url_id"></a> [lambda\_function\_url\_id](#output\_lambda\_function\_url\_id) | The Lambda Function URL generated id |
 | <a name="output_lambda_function_version"></a> [lambda\_function\_version](#output\_lambda\_function\_version) | Latest published version of Lambda Function |
 | <a name="output_lambda_layer_arn"></a> [lambda\_layer\_arn](#output\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_lambda_layer_code_sha256"></a> [lambda\_layer\_code\_sha256](#output\_lambda\_layer\_code\_sha256) | Base64-encoded representation of raw SHA-256 sum of the zip file |
 | <a name="output_lambda_layer_created_date"></a> [lambda\_layer\_created\_date](#output\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
 | <a name="output_lambda_layer_layer_arn"></a> [lambda\_layer\_layer\_arn](#output\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_lambda_layer_signing_job_arn"></a> [lambda\_layer\_signing\_job\_arn](#output\_lambda\_layer\_signing\_job\_arn) | ARN of a signing job |
+| <a name="output_lambda_layer_signing_profile_version_arn"></a> [lambda\_layer\_signing\_profile\_version\_arn](#output\_lambda\_layer\_signing\_profile\_version\_arn) | ARN for a signing profile version |
 | <a name="output_lambda_layer_source_code_size"></a> [lambda\_layer\_source\_code\_size](#output\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
 | <a name="output_lambda_layer_version"></a> [lambda\_layer\_version](#output\_lambda\_layer\_version) | The Lambda Layer version |
 | <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -91,6 +91,21 @@ output "lambda_layer_version" {
   value       = module.lambda_function.lambda_layer_version
 }
 
+output "lambda_layer_code_sha256" {
+  description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
+  value       = module.lambda_function.lambda_layer_code_sha256
+}
+
+output "lambda_layer_signing_job_arn" {
+  description = "ARN of a signing job"
+  value       = module.lambda_function.lambda_layer_signing_job_arn
+}
+
+output "lambda_layer_signing_profile_version_arn" {
+  description = "ARN for a signing profile version"
+  value       = module.lambda_function.lambda_layer_signing_profile_version_arn
+}
+
 # IAM Role
 output "lambda_role_arn" {
   description = "The ARN of the IAM role created for the Lambda Function"

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -91,21 +91,6 @@ output "lambda_layer_version" {
   value       = module.lambda_function.lambda_layer_version
 }
 
-output "lambda_layer_code_sha256" {
-  description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
-  value       = module.lambda_function.lambda_layer_code_sha256
-}
-
-output "lambda_layer_signing_job_arn" {
-  description = "ARN of a signing job"
-  value       = module.lambda_function.lambda_layer_signing_job_arn
-}
-
-output "lambda_layer_signing_profile_version_arn" {
-  description = "ARN for a signing profile version"
-  value       = module.lambda_function.lambda_layer_signing_profile_version_arn
-}
-
 # IAM Role
 output "lambda_role_arn" {
   description = "The ARN of the IAM role created for the Lambda Function"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/deploy/versions.tf
+++ b/examples/deploy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/event-source-mapping/README.md
+++ b/examples/event-source-mapping/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/event-source-mapping/README.md
+++ b/examples/event-source-mapping/README.md
@@ -61,6 +61,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_lambda_event_source_mapping_arn"></a> [lambda\_event\_source\_mapping\_arn](#output\_lambda\_event\_source\_mapping\_arn) | The event source mapping ARN |
 | <a name="output_lambda_event_source_mapping_function_arn"></a> [lambda\_event\_source\_mapping\_function\_arn](#output\_lambda\_event\_source\_mapping\_function\_arn) | The the ARN of the Lambda function the event source mapping is sending events to |
 | <a name="output_lambda_event_source_mapping_state"></a> [lambda\_event\_source\_mapping\_state](#output\_lambda\_event\_source\_mapping\_state) | The state of the event source mapping |
 | <a name="output_lambda_event_source_mapping_state_transition_reason"></a> [lambda\_event\_source\_mapping\_state\_transition\_reason](#output\_lambda\_event\_source\_mapping\_state\_transition\_reason) | The reason the event source mapping is in its current state |

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -83,6 +83,7 @@ module "lambda_function" {
           uri  = "/"
         }
       ]
+      tags = { mapping = "amq" }
     }
     #    self_managed_kafka = {
     #      batch_size        = 1
@@ -179,6 +180,10 @@ module "lambda_function" {
     "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole",
     "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole",
   ]
+
+  tags = {
+    example = "event-source-mapping"
+  }
 }
 
 ##################

--- a/examples/event-source-mapping/outputs.tf
+++ b/examples/event-source-mapping/outputs.tf
@@ -69,3 +69,8 @@ output "lambda_event_source_mapping_uuid" {
   description = "The UUID of the created event source mapping"
   value       = module.lambda_function.lambda_event_source_mapping_uuid
 }
+
+output "lambda_event_source_mapping_arn" {
+  description = "The event source mapping ARN"
+  value       = module.lambda_function.lambda_event_source_mapping_arn
+}

--- a/examples/event-source-mapping/versions.tf
+++ b/examples/event-source-mapping/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/multiple-regions/README.md
+++ b/examples/multiple-regions/README.md
@@ -21,15 +21,15 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/multiple-regions/versions.tf
+++ b/examples/multiple-regions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/runtimes/README.md
+++ b/examples/runtimes/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -32,7 +32,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_http"></a> [http](#provider\_http) | >= 3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/examples/runtimes/versions.tf
+++ b/examples/runtimes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/simple-cicd/README.md
+++ b/examples/simple-cicd/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/simple-cicd/versions.tf
+++ b/examples/simple-cicd/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/triggers/versions.tf
+++ b/examples/triggers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-efs/README.md
+++ b/examples/with-efs/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/with-efs/versions.tf
+++ b/examples/with-efs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-vpc-s3-endpoint/README.md
+++ b/examples/with-vpc-s3-endpoint/README.md
@@ -22,14 +22,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.4 |
 
 ## Modules

--- a/examples/with-vpc-s3-endpoint/versions.tf
+++ b/examples/with-vpc-s3-endpoint/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/with-vpc/versions.tf
+++ b/examples/with-vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -405,7 +405,7 @@ resource "aws_lambda_event_source_mapping" "this" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, try(each.value.tags, {}))
 }
 
 resource "aws_lambda_function_url" "this" {

--- a/main.tf
+++ b/main.tf
@@ -92,8 +92,9 @@ resource "aws_lambda_function" "this" {
   dynamic "vpc_config" {
     for_each = var.vpc_subnet_ids != null && var.vpc_security_group_ids != null ? [true] : []
     content {
-      security_group_ids = var.vpc_security_group_ids
-      subnet_ids         = var.vpc_subnet_ids
+      security_group_ids          = var.vpc_security_group_ids
+      subnet_ids                  = var.vpc_subnet_ids
+      ipv6_allowed_for_dual_stack = var.ipv6_allowed_for_dual_stack
     }
   }
 
@@ -403,6 +404,8 @@ resource "aws_lambda_event_source_mapping" "this" {
       full_document   = try(document_db_event_source_config.value.full_document, null)
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_lambda_function_url" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -81,6 +81,11 @@ output "lambda_layer_arn" {
   value       = try(aws_lambda_layer_version.this[0].arn, "")
 }
 
+output "lambda_layer_code_sha256" {
+  description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
+  value       = try(aws_lambda_layer_version.this[0].code_sha256, "")
+}
+
 output "lambda_layer_layer_arn" {
   description = "The ARN of the Lambda Layer without version"
   value       = try(aws_lambda_layer_version.this[0].layer_arn, "")
@@ -89,6 +94,16 @@ output "lambda_layer_layer_arn" {
 output "lambda_layer_created_date" {
   description = "The date Lambda Layer resource was created"
   value       = try(aws_lambda_layer_version.this[0].created_date, "")
+}
+
+output "lambda_layer_signing_job_arn" {
+  description = "ARN of a signing job"
+  value       = try(aws_lambda_layer_version.this[0].signing_job_arn, "")
+}
+
+output "signing_profile_version_arn" {
+  description = "ARN for a signing profile version"
+  value       = try(aws_lambda_layer_version.this[0].signing_profile_version_arn, "")
 }
 
 output "lambda_layer_source_code_size" {
@@ -102,6 +117,11 @@ output "lambda_layer_version" {
 }
 
 # Lambda Event Source Mapping
+output "lambda_event_source_mapping_arn" {
+  description = "The event source mapping ARN"
+  value       = { for k, v in aws_lambda_event_source_mapping.this : k => v.arn }
+}
+
 output "lambda_event_source_mapping_function_arn" {
   description = "The the ARN of the Lambda function the event source mapping is sending events to"
   value       = { for k, v in aws_lambda_event_source_mapping.this : k => v.function_arn }

--- a/outputs.tf
+++ b/outputs.tf
@@ -101,7 +101,7 @@ output "lambda_layer_signing_job_arn" {
   value       = try(aws_lambda_layer_version.this[0].signing_job_arn, "")
 }
 
-output "signing_profile_version_arn" {
+output "lambda_layer_signing_profile_version_arn" {
   description = "ARN for a signing profile version"
   value       = try(aws_lambda_layer_version.this[0].signing_profile_version_arn, "")
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -81,11 +81,6 @@ output "lambda_layer_arn" {
   value       = try(aws_lambda_layer_version.this[0].arn, "")
 }
 
-output "lambda_layer_code_sha256" {
-  description = "Base64-encoded representation of raw SHA-256 sum of the zip file"
-  value       = try(aws_lambda_layer_version.this[0].code_sha256, "")
-}
-
 output "lambda_layer_layer_arn" {
   description = "The ARN of the Lambda Layer without version"
   value       = try(aws_lambda_layer_version.this[0].layer_arn, "")
@@ -94,16 +89,6 @@ output "lambda_layer_layer_arn" {
 output "lambda_layer_created_date" {
   description = "The date Lambda Layer resource was created"
   value       = try(aws_lambda_layer_version.this[0].created_date, "")
-}
-
-output "lambda_layer_signing_job_arn" {
-  description = "ARN of a signing job"
-  value       = try(aws_lambda_layer_version.this[0].signing_job_arn, "")
-}
-
-output "lambda_layer_signing_profile_version_arn" {
-  description = "ARN for a signing profile version"
-  value       = try(aws_lambda_layer_version.this[0].signing_profile_version_arn, "")
 }
 
 output "lambda_layer_source_code_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,12 @@ variable "vpc_security_group_ids" {
   default     = null
 }
 
+variable "ipv6_allowed_for_dual_stack" {
+  description = "Allows outbound IPv6 traffic on VPC functions that are connected to dual-stack subnets"
+  type        = bool
+  default     = null
+}
+
 variable "tags" {
   description = "A map of tags to assign to resources."
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     external = {
       source  = "hashicorp/external"

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -68,6 +68,7 @@ module "wrapper" {
   image_config_working_directory               = try(each.value.image_config_working_directory, var.defaults.image_config_working_directory, null)
   image_uri                                    = try(each.value.image_uri, var.defaults.image_uri, null)
   invoke_mode                                  = try(each.value.invoke_mode, var.defaults.invoke_mode, null)
+  ipv6_allowed_for_dual_stack                  = try(each.value.ipv6_allowed_for_dual_stack, var.defaults.ipv6_allowed_for_dual_stack, null)
   kms_key_arn                                  = try(each.value.kms_key_arn, var.defaults.kms_key_arn, null)
   lambda_at_edge                               = try(each.value.lambda_at_edge, var.defaults.lambda_at_edge, false)
   lambda_at_edge_logs_all_regions              = try(each.value.lambda_at_edge_logs_all_regions, var.defaults.lambda_at_edge_logs_all_regions, true)

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.70"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
## Description
Add support for `vpc_config.ipv6_allowed_for_dual_stack` for lambda functions. 
Add support for `tags` in event source mappings. 
Add `lambda_event_source_mapping_arn` to outputs. 

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/39535
- https://github.com/hashicorp/terraform-provider-aws/pull/34045

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
