### PR TITLE
fix: prevent lambda IAM policies from detaching when orders are swapped

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -331,10 +331,10 @@ resource "aws_iam_role_policy_attachment" "additional_one" {
 ######################################
 
 resource "aws_iam_role_policy_attachment" "additional_many" {
-  count = local.create_role && var.attach_policies ? var.number_of_policies : 0
+  for_each = { for k, v in toset(var.policies) : k => v if local.create_role && var.attach_policies && var.number_of_policies > 0 }
 
   role       = aws_iam_role.lambda[0].name
-  policy_arn = var.policies[count.index]
+  policy_arn = each.value
 }
 
 ###############################


### PR DESCRIPTION
## Description
Used for loop instead of count for resource "aws_iam_role_policy_attachment" "additional_many" to ensure that changing orders of the policy will not detach them

## Motivation and Context

Fixes #629

I have a project on production where I used the module and added the policies to the lambda. 

Subsequently, I swapped the order of the policies and they got detached from the lambda, this caused a production issue as the lambda lacked permissions. Would like to ensure that this does not happen again. 


## Breaking Changes
None that I am aware of 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
There is no need to update as it applies to existing config

- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

- [ ] I have executed `pre-commit run -a` on my pull request
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/0a9e6b3f-c0c6-49da-88e6-31ab133d7ef5">
- terraform validate hook could not execute

I have also tested again the local code in the issue 
