### PR TITLE
feat: Allow temp dir for poetry docker builds

### DIFF
--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -426,7 +426,7 @@ module "lambda_layer_poetry" {
     {
       path           = "${path.module}/../fixtures/python-app-poetry"
       poetry_install = true
-      poetry_tmp_dir = "${path.root}/builds/"
+      poetry_tmp_dir = "${path.cwd}/../fixtures"
     }
   ]
   hash_extra = "extra-hash-to-prevent-conflicts-with-module.package_dir"

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -426,6 +426,7 @@ module "lambda_layer_poetry" {
     {
       path           = "${path.module}/../fixtures/python-app-poetry"
       poetry_install = true
+      poetry_tmp_dir = "${path.root}/builds/"
     }
   ]
   hash_extra = "extra-hash-to-prevent-conflicts-with-module.package_dir"

--- a/package.py
+++ b/package.py
@@ -1195,7 +1195,6 @@ def install_poetry_dependencies(query, path, poetry_export_extra_args, tmp_dir):
         poetry_exec = "poetry"
         python_exec = runtime
         subproc_env = None
-        log.info("Dir contents: %s",os.listdir(temp_dir))
 
         if not docker:
             if WINDOWS:

--- a/package.py
+++ b/package.py
@@ -1193,6 +1193,7 @@ def install_poetry_dependencies(query, path, poetry_export_extra_args):
         poetry_exec = "poetry"
         python_exec = runtime
         subproc_env = None
+        log.info("Dir contents: %s",os.listdir(temp_dir))
 
         if not docker:
             if WINDOWS:

--- a/package.py
+++ b/package.py
@@ -840,7 +840,7 @@ class BuildPlanManager:
                                 prefix=prefix,
                                 poetry_export_extra_args=poetry_export_extra_args,
                                 required=True,
-                                tmp_dir=claim.get("poetry_tmp_dir")
+                                tmp_dir=claim.get("poetry_tmp_dir"),
                             )
 
                     if npm_requirements and runtime.startswith("nodejs"):
@@ -911,13 +911,7 @@ class BuildPlanManager:
                             # XXX: timestamp=0 - what actually do with it?
                             zs.write_dirs(rd, prefix=prefix, timestamp=0)
             elif cmd == "poetry":
-                (
-                    runtime,
-                    path,
-                    poetry_export_extra_args,
-                    prefix,
-                    tmp_dir
-                ) = action[1:]
+                (runtime, path, poetry_export_extra_args, prefix, tmp_dir) = action[1:]
                 log.info("poetry_export_extra_args: %s", poetry_export_extra_args)
                 with install_poetry_dependencies(
                     query, path, poetry_export_extra_args, tmp_dir

--- a/package.py
+++ b/package.py
@@ -948,14 +948,18 @@ class BuildPlanManager:
                                 # XXX: timestamp=0 - what actually do with it?
                                 zs.write_dirs(rd, prefix=prefix, timestamp=0)
                 elif cmd == "poetry":
-                    (runtime, path, poetry_export_extra_args, prefix, tmp_dir) = action[1:]
+                    (runtime, path, poetry_export_extra_args, prefix, tmp_dir) = action[
+                        1:
+                    ]
                     log.info("poetry_export_extra_args: %s", poetry_export_extra_args)
                     with install_poetry_dependencies(
                         query, path, poetry_export_extra_args, tmp_dir
                     ) as rd:
                         if rd:
                             if pf:
-                                self._zip_write_with_filter(zs, pf, rd, prefix, timestamp=0)
+                                self._zip_write_with_filter(
+                                    zs, pf, rd, prefix, timestamp=0
+                                )
                             else:
                                 # XXX: timestamp=0 - what actually do with it?
                                 zs.write_dirs(rd, prefix=prefix, timestamp=0)


### PR DESCRIPTION
## Description
Allows optionally specifying a temp dir for poetry to bring parity with npm and pip

## Motivation and Context
Docker CLI on ubuntu default for github actions, does not allow mounting /tmp https://stackoverflow.com/questions/65267251/docker-bind-mount-directory-in-tmp-not-working
This results in a frustrating situation where terraform passes locally but fails with strange error in CI pipeline.

Fixes: #545 

## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
Added temp dir to one poetry example and left rest untouched to prove not breaking change
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
