### PR TITLE
feat: Make `source_path` blocks independent

### DIFF
--- a/package.py
+++ b/package.py
@@ -905,7 +905,9 @@ class BuildPlanManager:
                     log.debug("WORKDIR: %s", sh_work_dir)
                 if source_path:
                     if not os.path.isabs(source_path):
-                        source_path = os.path.join(sh_work_dir, source_path)
+                        source_path = os.path.normpath(
+                            os.path.join(sh_work_dir, source_path)
+                        )
                 else:
                     source_path = sh_work_dir
                 if os.path.isdir(source_path):
@@ -959,7 +961,7 @@ class BuildPlanManager:
                     if not path:
                         path = tf_work_dir
                     if not os.path.isabs(path):
-                        path = os.path.join(tf_work_dir, path)
+                        path = os.path.normpath(os.path.join(tf_work_dir, path))
 
                     if log.isEnabledFor(DEBUG2):
                         log.debug("exec shell script ...")

--- a/package.py
+++ b/package.py
@@ -770,8 +770,9 @@ class BuildPlanManager:
                             _path = os.path.normpath(os.path.join(path, _path))
                             step("zip:embedded", _path, prefix)
                         elif len(c) == 2:
-                            prefix = None
                             _, _path = c
+                            prefix = None
+                            _path = os.path.normpath(_path)
                             step("zip:embedded", _path, prefix)
                         elif len(c) == 1:
                             prefix = None
@@ -862,6 +863,7 @@ class BuildPlanManager:
                                 tmp_dir=claim.get("npm_tmp_dir"),
                             )
                     if path:
+                        path = os.path.normpath(path)
                         step("zip", path, prefix)
                         if patterns:
                             # Take patterns into account when computing hash

--- a/package.py
+++ b/package.py
@@ -676,8 +676,11 @@ class BuildPlanManager:
         source_paths = []
         build_plan = []
 
-        step = lambda *x: build_plan.append(x)
-        hash = source_paths.append
+        def step(*x):
+            build_plan.append(x)
+
+        def hash(path):
+            source_paths.append(path)
 
         def pip_requirements_step(path, prefix=None, required=False, tmp_dir=None):
             command = runtime
@@ -753,13 +756,6 @@ class BuildPlanManager:
                     if c.startswith(":zip"):
                         if path:
                             hash(path)
-                        else:
-                            # If path doesn't defined for a block with
-                            # commands it will be set to Terraform's
-                            # current working directory
-                            # NB: cwd may vary when using Terraform 0.14+ like:
-                            # `terraform -chdir=...`
-                            path = query.paths.cwd
                         if batch:
                             step("sh", path, "\n".join(batch))
                             batch.clear()


### PR DESCRIPTION
fe72310 fix: improve sh exec step debug logging
a4fd2e1 feat: allow to don't specify `path` in `source_path` and use explicit `:zip` commands
aa2cb10 fix: make `source_path` blocks independent
> The `source_path` blocks don't impact anymore to each other by workdir changes

38d6715 fix: unify `:zip` path normalization

---

Maybe it makes sense to bump major release version due to changed `source_path` blocks behavior.