### PR TITLE
fix: Revert breaking change on :zip command

### DIFF
--- a/package.py
+++ b/package.py
@@ -776,8 +776,7 @@ class BuildPlanManager:
                             step("zip:embedded", _path, prefix)
                         elif len(c) == 1:
                             prefix = None
-                            _path = None
-                            step("zip:embedded", _path, prefix)
+                            step("zip:embedded", path, prefix)
                         else:
                             raise ValueError(
                                 ":zip invalid call signature, use: "


### PR DESCRIPTION
## Description
Lambda 7.15.0 intorduced with [https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/640](https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/640) a breaking change. The `:zip` command without any arguments is using the current working directory instead of the specified `path` attribute. This breaks the examples from README.md, where the resulting zip files contains more files, with different paths. This PR reverts the change to use the specified path again.

See issue #644 for a detailed description of the issue, including examples.

## Motivation and Context
7.15.0 introduced a breaking change on ignoring the path when specifying the `:zip` command.
The PR that introduced the breaking change: [https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/640](https://github.com/terraform-aws-modules/terraform-aws-lambda/pull/640)

## Breaking Changes
No, it reverts a breaking change from 7.15.0.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
