### PR TITLE
feat: Support passing extra args to pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ source_path = [
   - `:zip [source] [destination]` is a special command which creates content of current working directory (first argument) and places it inside of path (second argument).
 - `pip_requirements` - Controls whether to execute `pip install`. Set to `false` to disable this feature, `true` to run `pip install` with `requirements.txt` found in `path`. Or set to another filename which you want to use instead. When `source_path` is passed as a string containing a path (and not a list of maps), and `requirements.txt` is present, `pip install` is automatically executed.
 - `pip_tmp_dir` - Set the base directory to make the temporary directory for pip installs. Can be useful for Docker in Docker builds.
+- `pip_install_extra_args` - A list of additional pip arguments to add to the pip install command
 - `poetry_install` - Controls whether to execute `poetry export` and `pip install`. Set to `false` to disable this feature, `true` to run `poetry export` with `pyproject.toml` and `poetry.lock` found in `path`. When `source_path` is passed as a string containing a path (and not a list of maps), and `pyproject.toml` with a build system `poetry` is present, `poetry export` and `pip install` are automatically executed.
 - `poetry_export_extra_args` - A list of additional poetry arguments to add to the poetry export command
 - `npm_requirements` - Controls whether to execute `npm install`. Set to `false` to disable this feature, `true` to run `npm install` with `package.json` found in `path`. Or set to another filename which you want to use instead.

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -151,10 +151,10 @@ No modules.
 | <a name="input_attach_hooks_policy"></a> [attach\_hooks\_policy](#input\_attach\_hooks\_policy) | Whether to attach Invoke policy to CodeDeploy role when before allow traffic or after allow traffic hooks are defined. | `bool` | `true` | no |
 | <a name="input_attach_triggers_policy"></a> [attach\_triggers\_policy](#input\_attach\_triggers\_policy) | Whether to attach SNS policy to CodeDeploy role when triggers are defined | `bool` | `false` | no |
 | <a name="input_auto_rollback_enabled"></a> [auto\_rollback\_enabled](#input\_auto\_rollback\_enabled) | Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. | `bool` | `true` | no |
-| <a name="input_auto_rollback_events"></a> [auto\_rollback\_events](#input\_auto\_rollback\_events) | List of event types that trigger a rollback. Supported types are DEPLOYMENT\_FAILURE and DEPLOYMENT\_STOP\_ON\_ALARM. | `list(string)` | <pre>[<br>  "DEPLOYMENT_STOP_ON_ALARM"<br>]</pre> | no |
+| <a name="input_auto_rollback_events"></a> [auto\_rollback\_events](#input\_auto\_rollback\_events) | List of event types that trigger a rollback. Supported types are DEPLOYMENT\_FAILURE and DEPLOYMENT\_STOP\_ON\_ALARM. | `list(string)` | <pre>[<br/>  "DEPLOYMENT_STOP_ON_ALARM"<br/>]</pre> | no |
 | <a name="input_aws_cli_command"></a> [aws\_cli\_command](#input\_aws\_cli\_command) | Command to run as AWS CLI. May include extra arguments like region and profile. | `string` | `"aws"` | no |
 | <a name="input_before_allow_traffic_hook_arn"></a> [before\_allow\_traffic\_hook\_arn](#input\_before\_allow\_traffic\_hook\_arn) | ARN of Lambda function to execute before allow traffic during deployment. This function should be named CodeDeployHook\_, to match the managed AWSCodeDeployForLambda policy, unless you're using a custom role | `string` | `""` | no |
-| <a name="input_codedeploy_principals"></a> [codedeploy\_principals](#input\_codedeploy\_principals) | List of CodeDeploy service principals to allow. The list can include global or regional endpoints. | `list(string)` | <pre>[<br>  "codedeploy.amazonaws.com"<br>]</pre> | no |
+| <a name="input_codedeploy_principals"></a> [codedeploy\_principals](#input\_codedeploy\_principals) | List of CodeDeploy service principals to allow. The list can include global or regional endpoints. | `list(string)` | <pre>[<br/>  "codedeploy.amazonaws.com"<br/>]</pre> | no |
 | <a name="input_codedeploy_role_name"></a> [codedeploy\_role\_name](#input\_codedeploy\_role\_name) | IAM role name to create or use by CodeDeploy | `string` | `""` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls whether resources should be created | `bool` | `true` | no |
 | <a name="input_create_app"></a> [create\_app](#input\_create\_app) | Whether to create new AWS CodeDeploy app | `bool` | `false` | no |
@@ -168,7 +168,7 @@ No modules.
 | <a name="input_force_deploy"></a> [force\_deploy](#input\_force\_deploy) | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name of the Lambda function to deploy | `string` | `""` | no |
 | <a name="input_get_deployment_sleep_timer"></a> [get\_deployment\_sleep\_timer](#input\_get\_deployment\_sleep\_timer) | Adds additional sleep time to get-deployment command to avoid the service throttling | `number` | `5` | no |
-| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br>  "/bin/bash",<br>  "-c"<br>]</pre> | no |
+| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br/>  "/bin/bash",<br/>  "-c"<br/>]</pre> | no |
 | <a name="input_run_deployment"></a> [run\_deployment](#input\_run\_deployment) | Run AWS CLI command to start the deployment | `bool` | `false` | no |
 | <a name="input_save_deploy_script"></a> [save\_deploy\_script](#input\_save\_deploy\_script) | Save deploy script locally | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/modules/deploy/README.md
+++ b/modules/deploy/README.md
@@ -151,10 +151,10 @@ No modules.
 | <a name="input_attach_hooks_policy"></a> [attach\_hooks\_policy](#input\_attach\_hooks\_policy) | Whether to attach Invoke policy to CodeDeploy role when before allow traffic or after allow traffic hooks are defined. | `bool` | `true` | no |
 | <a name="input_attach_triggers_policy"></a> [attach\_triggers\_policy](#input\_attach\_triggers\_policy) | Whether to attach SNS policy to CodeDeploy role when triggers are defined | `bool` | `false` | no |
 | <a name="input_auto_rollback_enabled"></a> [auto\_rollback\_enabled](#input\_auto\_rollback\_enabled) | Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. | `bool` | `true` | no |
-| <a name="input_auto_rollback_events"></a> [auto\_rollback\_events](#input\_auto\_rollback\_events) | List of event types that trigger a rollback. Supported types are DEPLOYMENT\_FAILURE and DEPLOYMENT\_STOP\_ON\_ALARM. | `list(string)` | <pre>[<br/>  "DEPLOYMENT_STOP_ON_ALARM"<br/>]</pre> | no |
+| <a name="input_auto_rollback_events"></a> [auto\_rollback\_events](#input\_auto\_rollback\_events) | List of event types that trigger a rollback. Supported types are DEPLOYMENT\_FAILURE and DEPLOYMENT\_STOP\_ON\_ALARM. | `list(string)` | <pre>[<br>  "DEPLOYMENT_STOP_ON_ALARM"<br>]</pre> | no |
 | <a name="input_aws_cli_command"></a> [aws\_cli\_command](#input\_aws\_cli\_command) | Command to run as AWS CLI. May include extra arguments like region and profile. | `string` | `"aws"` | no |
 | <a name="input_before_allow_traffic_hook_arn"></a> [before\_allow\_traffic\_hook\_arn](#input\_before\_allow\_traffic\_hook\_arn) | ARN of Lambda function to execute before allow traffic during deployment. This function should be named CodeDeployHook\_, to match the managed AWSCodeDeployForLambda policy, unless you're using a custom role | `string` | `""` | no |
-| <a name="input_codedeploy_principals"></a> [codedeploy\_principals](#input\_codedeploy\_principals) | List of CodeDeploy service principals to allow. The list can include global or regional endpoints. | `list(string)` | <pre>[<br/>  "codedeploy.amazonaws.com"<br/>]</pre> | no |
+| <a name="input_codedeploy_principals"></a> [codedeploy\_principals](#input\_codedeploy\_principals) | List of CodeDeploy service principals to allow. The list can include global or regional endpoints. | `list(string)` | <pre>[<br>  "codedeploy.amazonaws.com"<br>]</pre> | no |
 | <a name="input_codedeploy_role_name"></a> [codedeploy\_role\_name](#input\_codedeploy\_role\_name) | IAM role name to create or use by CodeDeploy | `string` | `""` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls whether resources should be created | `bool` | `true` | no |
 | <a name="input_create_app"></a> [create\_app](#input\_create\_app) | Whether to create new AWS CodeDeploy app | `bool` | `false` | no |
@@ -168,7 +168,7 @@ No modules.
 | <a name="input_force_deploy"></a> [force\_deploy](#input\_force\_deploy) | Force deployment every time (even when nothing changes) | `bool` | `false` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name of the Lambda function to deploy | `string` | `""` | no |
 | <a name="input_get_deployment_sleep_timer"></a> [get\_deployment\_sleep\_timer](#input\_get\_deployment\_sleep\_timer) | Adds additional sleep time to get-deployment command to avoid the service throttling | `number` | `5` | no |
-| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br/>  "/bin/bash",<br/>  "-c"<br/>]</pre> | no |
+| <a name="input_interpreter"></a> [interpreter](#input\_interpreter) | List of interpreter arguments used to execute deploy script, first arg is path | `list(string)` | <pre>[<br>  "/bin/bash",<br>  "-c"<br>]</pre> | no |
 | <a name="input_run_deployment"></a> [run\_deployment](#input\_run\_deployment) | Run AWS CLI command to start the deployment | `bool` | `false` | no |
 | <a name="input_save_deploy_script"></a> [save\_deploy\_script](#input\_save\_deploy\_script) | Save deploy script locally | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/package.py
+++ b/package.py
@@ -687,7 +687,9 @@ class BuildPlanManager:
         def hash(path):
             source_paths.append(path)
 
-        def pip_requirements_step(path, prefix=None, required=False, tmp_dir=None, pip_install_extra_args=[]):
+        def pip_requirements_step(
+            path, prefix=None, required=False, tmp_dir=None, pip_install_extra_args=[]
+        ):
             command = runtime
             requirements = path
             if os.path.isdir(path):
@@ -703,11 +705,23 @@ class BuildPlanManager:
                         "available in system PATH".format(command)
                     )
 
-                step("pip", runtime, requirements, prefix, tmp_dir, pip_install_extra_args)
+                step(
+                    "pip",
+                    runtime,
+                    requirements,
+                    prefix,
+                    tmp_dir,
+                    pip_install_extra_args,
+                )
                 hash(requirements)
 
         def poetry_install_step(
-            path, poetry_export_extra_args=[], prefix=None, required=False, tmp_dir=None, pip_install_extra_args=[]
+            path,
+            poetry_export_extra_args=[],
+            prefix=None,
+            required=False,
+            tmp_dir=None,
+            pip_install_extra_args=[],
         ):
             pyproject_file = path
             if os.path.isdir(path):
@@ -718,7 +732,15 @@ class BuildPlanManager:
                         "poetry configuration not found: {}".format(pyproject_file)
                     )
             else:
-                step("poetry", runtime, path, poetry_export_extra_args, prefix, tmp_dir, pip_install_extra_args)
+                step(
+                    "poetry",
+                    runtime,
+                    path,
+                    poetry_export_extra_args,
+                    prefix,
+                    tmp_dir,
+                    pip_install_extra_args,
+                )
                 hash(pyproject_file)
                 pyproject_path = os.path.dirname(pyproject_file)
                 poetry_lock_file = os.path.join(pyproject_path, "poetry.lock")
@@ -941,7 +963,13 @@ class BuildPlanManager:
                     else:
                         zs.write_file(source_path, prefix=prefix, timestamp=ts)
                 elif cmd == "pip":
-                    runtime, pip_requirements, prefix, tmp_dir, pip_install_extra_args = action[1:]
+                    (
+                        runtime,
+                        pip_requirements,
+                        prefix,
+                        tmp_dir,
+                        pip_install_extra_args,
+                    ) = action[1:]
                     with install_pip_requirements(
                         query, pip_requirements, tmp_dir, pip_install_extra_args
                     ) as rd:
@@ -954,12 +982,21 @@ class BuildPlanManager:
                                 # XXX: timestamp=0 - what actually do with it?
                                 zs.write_dirs(rd, prefix=prefix, timestamp=0)
                 elif cmd == "poetry":
-                    (runtime, path, poetry_export_extra_args, prefix, tmp_dir, pip_install_extra_args) = action[
-                        1:
-                    ]
+                    (
+                        runtime,
+                        path,
+                        poetry_export_extra_args,
+                        prefix,
+                        tmp_dir,
+                        pip_install_extra_args,
+                    ) = action[1:]
                     log.info("poetry_export_extra_args: %s", poetry_export_extra_args)
                     with install_poetry_dependencies(
-                        query, path, poetry_export_extra_args, tmp_dir, pip_install_extra_args
+                        query,
+                        path,
+                        poetry_export_extra_args,
+                        tmp_dir,
+                        pip_install_extra_args,
                     ) as rd:
                         if rd:
                             if pf:
@@ -1179,7 +1216,9 @@ def install_pip_requirements(query, requirements_file, tmp_dir, pip_install_extr
 
 
 @contextmanager
-def install_poetry_dependencies(query, path, poetry_export_extra_args, tmp_dir, pip_install_extra_args):
+def install_poetry_dependencies(
+    query, path, poetry_export_extra_args, tmp_dir, pip_install_extra_args
+):
     # TODO:
     #  1. Emit files instead of temp_dir
 
@@ -1305,7 +1344,8 @@ def install_poetry_dependencies(query, path, poetry_export_extra_args, tmp_dir, 
                     "--prefix=",
                     "--target=.",
                     "--requirement=requirements.txt",
-                ] + pip_install_extra_args,
+                ]
+                + pip_install_extra_args,
             ]
             if docker:
                 with_ssh_agent = docker.with_ssh_agent


### PR DESCRIPTION
## Description
Added support to pass extra arguments to pip install command

```
{
  path                   = "src/python-app1",
  pip_requirements       = true,
  pip_install_extra_args = ["--platform", "manylinux2014_aarch64", "--only-binary", ":all:"]
}
```

## Motivation and Context
Due to limitations with our CI, we can't use docker when installing and zipping requirements.
To overcome this we use the `platform` flag when running pip install to download the right distribution per lambda architecture.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I have tested these changes locally and deployed a lambda to AWS. I am happy to do additional testing if necessary.

- [x] I have executed `pre-commit run -a` on my pull request

