### PR TITLE
feat: Optionally allow list of additional CLI options to send to pip install

### DIFF
--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -165,6 +165,24 @@ module "package_file_with_pip_requirements" {
 
 # Create zip-archive which contains:
 # 1. A single file - index.py
+# 2. Run "pip install" with specified requirements.txt with additional options CLI --only-binary=:all: --platform manylinux2014_x86_64
+module "package_file_with_pip_requirements_and_pip_additional_options" {
+  source = "../../"
+
+  create_function = false
+
+  runtime = "python3.12"
+  pip_additional_options = ["-only-binary=:all:", "--platform", "manylinux2014_x86_64"]
+  source_path = [
+    "${path.module}/../fixtures/python-app1/index.py",
+    {
+      pip_requirements = "${path.module}/../fixtures/python-app1/requirements.txt"
+    }
+  ]
+}
+
+# Create zip-archive which contains:
+# 1. A single file - index.py
 # 2. Content of directory "dir2"
 # 3. Install pip requirements
 # "pip install" is running in a Docker container for the specified runtime

--- a/package.py
+++ b/package.py
@@ -1060,6 +1060,7 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
     artifacts_dir = query.artifacts_dir
     docker = query.docker
     temp_dir = query.temp_dir
+    pip_additional_options = query.pip_additional_options
     docker_image_tag_id = None
 
     if docker:
@@ -1125,7 +1126,7 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
                 "--prefix=",
                 "--target=.",
                 "--requirement={}".format(requirements_filename),
-            ]
+            ] + pip_additional_options
             if docker:
                 with_ssh_agent = docker.with_ssh_agent
                 pip_cache_dir = docker.docker_pip_cache

--- a/package.tf
+++ b/package.tf
@@ -40,6 +40,8 @@ data "external" "archive_prepare" {
     )
 
     recreate_missing_package = var.recreate_missing_package
+
+    pip_additional_options = jsonencode(var.pip_additional_options)
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -806,6 +806,12 @@ variable "trigger_on_package_timestamp" {
   default     = true
 }
 
+variable "pip_additional_options" {
+  description = "Additional options to pass to the pip install command (e.g. to platform, etc.)"
+  type        = list(string)
+  default     = []
+}
+
 ############################################
 # Lambda Advanced Logging Settings
 ############################################


### PR DESCRIPTION
## Description

Optionally allow list of additional CLI options to send to pip install

This is helpful for cross-platform builds such as packaging in an alpine context for an al2 runtime context

## Motivation and Context

Fixes https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/668

## Breaking Changes

No, this is done using a default value of [] which should be a non-breaking addition

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
