### PR TITLE
Fix(lambda_update): ignore image_uri based on a var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,17 @@ resource "aws_lambda_function" "this" {
   replacement_security_group_ids     = var.replacement_security_group_ids
   skip_destroy                       = var.skip_destroy
 
+  /* ignore image_uri when var.ignore_image_uri is true */
+  dynamic "lifecycle" {
+    for_each = var.ignore_image_uri ? [1] : []
+
+    content {
+      ignore_changes = [
+        image_uri,
+      ]
+    }
+  }
+
   /* ephemeral_storage is not supported in gov-cloud region, so it should be set to `null` */
   dynamic "ephemeral_storage" {
     for_each = var.ephemeral_storage_size == null ? [] : [true]

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,12 @@ variable "image_uri" {
   default     = null
 }
 
+variable "ignore_image_uri" {
+  description = "Whether to ignore changes to the function's image URI. Set to true if you manage infrastructure and code deployments separately."
+  type        = bool
+  default     = false
+}
+
 variable "image_config_entry_point" {
   description = "The ENTRYPOINT for the docker image"
   type        = list(string)


### PR DESCRIPTION
## Description
Looking to implement ignore_image_uri when I want to manage the docker image deployment using a different pipeline outside terraform. 
Since ignore_source_code_hash already exist, I want to use the same pattern here.
