### PR TITLE
fix: Do not expose output from build command in Docker

### DIFF
--- a/package.tf
+++ b/package.tf
@@ -49,7 +49,7 @@ data "external" "archive_prepare" {
 resource "local_file" "archive_plan" {
   count = var.create && var.create_package ? 1 : 0
 
-  content              = var.build_in_docker && anytrue([for option in var.docker_additional_options : issensitive(option)]) ? sensitive(data.external.archive_prepare[0].result.build_plan) : data.external.archive_prepare[0].result.build_plan
+  content              = var.build_in_docker ? sensitive(data.external.archive_prepare[0].result.build_plan) : data.external.archive_prepare[0].result.build_plan
   filename             = data.external.archive_prepare[0].result.build_plan_filename
   directory_permission = "0755"
   file_permission      = "0644"

--- a/package.tf
+++ b/package.tf
@@ -49,7 +49,7 @@ data "external" "archive_prepare" {
 resource "local_file" "archive_plan" {
   count = var.create && var.create_package ? 1 : 0
 
-  content              = data.external.archive_prepare[0].result.build_plan
+  content              = var.build_in_docker && anytrue([for option in var.docker_additional_options : issensitive(option)]) ? sensitive(data.external.archive_prepare[0].result.build_plan) : data.external.archive_prepare[0].result.build_plan
   filename             = data.external.archive_prepare[0].result.build_plan_filename
   directory_permission = "0755"
   file_permission      = "0644"


### PR DESCRIPTION
## Description
If dependencies build is performed using Docker, and additional Docker options are specified, and any of those options contain a sensitive value, the content of the archive file has also to be marked as sensitive, to avoid exposing these sensitive options in the Terraform plan. Unfortunately the `external` provider [doesn't support marking output values as sensitive](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external#result-1), so this workaround seems like an only viable solution.

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/676.

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request