### PR TITLE
feat: Add buildx and multi-stage build support to docker-build module

### DIFF
--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -37,6 +37,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_docker_build"></a> [docker\_build](#module\_docker\_build) | ../../modules/docker-build | n/a |
 | <a name="module_docker_build_from_ecr"></a> [docker\_build\_from\_ecr](#module\_docker\_build\_from\_ecr) | ../../modules/docker-build | n/a |
+| <a name="module_docker_build_multistage"></a> [docker\_build\_multistage](#module\_docker\_build\_multistage) | ../../modules/docker-build | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | terraform-aws-modules/ecr/aws | n/a |
 | <a name="module_lambda_function_with_docker_build"></a> [lambda\_function\_with\_docker\_build](#module\_lambda\_function\_with\_docker\_build) | ../../ | n/a |
 | <a name="module_lambda_function_with_docker_build_from_ecr"></a> [lambda\_function\_with\_docker\_build\_from\_ecr](#module\_lambda\_function\_with\_docker\_build\_from\_ecr) | ../../ | n/a |

--- a/examples/container-image/context/Dockerfile
+++ b/examples/container-image/context/Dockerfile
@@ -1,8 +1,12 @@
 # `--platform` argument is used to be able to build docker images when using another platform (e.g. Apple M1)
-FROM --platform=linux/x86_64 scratch
+FROM --platform=linux/x86_64 scratch AS first_stage
 
 ARG FOO
 
 ENV FOO $FOO
 
 COPY empty /empty
+
+FROM first_stage AS second_stage
+
+COPY empty /empty_two

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -123,6 +123,35 @@ module "docker_build_from_ecr" {
   build_args = {
     FOO = "bar"
   }
+  # Can also use buildx
+  builder          = "default"
+  docker_file_path = "${local.source_path}/Dockerfile"
+
+  triggers = {
+    dir_sha = local.dir_sha
+  }
+
+  cache_from = ["${module.ecr.repository_url}:latest"]
+}
+
+module "docker_build_multistage" {
+  source = "../../modules/docker-build"
+
+  ecr_repo = module.ecr.repository_name
+
+  use_image_tag = true
+  image_tag     = "first_stage"
+
+  source_path = local.source_path
+  platform    = "linux/amd64"
+  build_args = {
+    FOO = "bar"
+  }
+  builder          = "default"
+  docker_file_path = "${local.source_path}/Dockerfile"
+
+  # multi-stage builds
+  build_target = "first_stage"
 
   triggers = {
     dir_sha = local.dir_sha

--- a/modules/docker-build/README.md
+++ b/modules/docker-build/README.md
@@ -59,7 +59,7 @@ module "docker_image" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 3.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | >= 3.5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
@@ -67,7 +67,7 @@ module "docker_image" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
-| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 3.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | >= 3.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules
@@ -91,6 +91,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_build_args"></a> [build\_args](#input\_build\_args) | A map of Docker build arguments. | `map(string)` | `{}` | no |
+| <a name="input_build_target"></a> [build\_target](#input\_build\_target) | Set the target build stage to build | `string` | `null` | no |
+| <a name="input_builder"></a> [builder](#input\_builder) | The buildx builder to use for the Docker build. | `string` | `null` | no |
 | <a name="input_cache_from"></a> [cache\_from](#input\_cache\_from) | List of images to consider as cache sources when building the image. | `list(string)` | `[]` | no |
 | <a name="input_create_ecr_repo"></a> [create\_ecr\_repo](#input\_create\_ecr\_repo) | Controls whether ECR repository for Lambda image should be created | `bool` | `false` | no |
 | <a name="input_create_sam_metadata"></a> [create\_sam\_metadata](#input\_create\_sam\_metadata) | Controls whether the SAM metadata null resource should be created | `bool` | `false` | no |

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -16,6 +16,8 @@ resource "docker_image" "this" {
     context    = var.source_path
     dockerfile = var.docker_file_path
     build_args = var.build_args
+    builder    = var.builder
+    target     = var.build_target
     platform   = var.platform
     cache_from = var.cache_from
   }

--- a/modules/docker-build/variables.tf
+++ b/modules/docker-build/variables.tf
@@ -71,10 +71,22 @@ variable "ecr_repo_tags" {
   default     = {}
 }
 
+variable "builder" {
+  description = "The buildx builder to use for the Docker build."
+  type        = string
+  default     = null
+}
+
 variable "build_args" {
   description = "A map of Docker build arguments."
   type        = map(string)
   default     = {}
+}
+
+variable "build_target" {
+  description = "Set the target build stage to build"
+  type        = string
+  default     = null
 }
 
 variable "ecr_repo_lifecycle_policy" {

--- a/modules/docker-build/versions.tf
+++ b/modules/docker-build/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = ">= 3.0"
+      version = ">= 3.5.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/wrappers/docker-build/main.tf
+++ b/wrappers/docker-build/main.tf
@@ -4,6 +4,8 @@ module "wrapper" {
   for_each = var.items
 
   build_args                = try(each.value.build_args, var.defaults.build_args, {})
+  build_target              = try(each.value.build_target, var.defaults.build_target, null)
+  builder                   = try(each.value.builder, var.defaults.builder, null)
   cache_from                = try(each.value.cache_from, var.defaults.cache_from, [])
   create_ecr_repo           = try(each.value.create_ecr_repo, var.defaults.create_ecr_repo, false)
   create_sam_metadata       = try(each.value.create_sam_metadata, var.defaults.create_sam_metadata, false)

--- a/wrappers/docker-build/versions.tf
+++ b/wrappers/docker-build/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = ">= 3.0"
+      version = ">= 3.5.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## Description
* Allow passing `builder` and `build_target` for `docker-build` module

## Motivation and Context
Buildx and multi-stage images are great. Let's use them!

## Breaking Changes
I believe these are backwards compatible

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
