### PR TITLE
fix: Update package.py

### DIFF
--- a/package.py
+++ b/package.py
@@ -1123,7 +1123,7 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
                 "install",
                 "--no-compile",
                 "--prefix=",
-                "--target=.",
+                "--target=python/.",
                 "--requirement={}".format(requirements_filename),
             ]
             if docker:


### PR DESCRIPTION
install_pip_requirements: fixing `--target` section of pip install, following aws documentation (https://docs.aws.amazon.com/lambda/latest/dg/python-layers.html)

## Description
<!--- Describe your changes in detail -->
Minor fix to pip requirements install path
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Following AWS documentation regarding `Working with layers for Python Lambda functions` (https://docs.aws.amazon.com/lambda/latest/dg/python-layers.html), the `--target` of `pip install` must have `Choose one of the following methods to install pip packages into the required top-level directory (python/):`
Without the implemented fix, a test of the lambda function returns an error (Examples below). 

Example module usage:
```
module "lambda_requests_layer" {
  source  = "terraform-aws-modules/lambda/aws"
  version = "7.21.0"

  create_layer = true

  layer_name          = "requests"
  runtime         = "python3.9"
  build_in_docker = true
  source_path = [{
    pip_tmp_dir      = "${path.module}/src/lambda/layer_tmp"
    pip_requirements = "${path.module}/src/lambda/requirements.txt"
  }]
  artifacts_dir = "${path.root}/.terraform/builds/${var.project_name}-requests"
}

module "lambda_fallback" {
  source  = "terraform-aws-modules/lambda/aws"
  version = "7.21.0"

  function_name           = "${var.project_name}-fallbacklambda"
  handler                 = "lambda_function_test.lambda_handler"
  runtime                 = "python3.9"
  source_path             = "${path.module}/src/lambda/lambda_function_test.py"
  layers = [module.lambda_requests_layer.lambda_layer_arn]
  publish                 = true
  ignore_source_code_hash = true
  attach_policies         = true
  number_of_policies      = 1
  policies = [
    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
  ]
  artifacts_dir           = "${path.root}/.terraform/builds/${var.project_name}-fallbacklambda"
}
```
Example requirements:
```
requests==2.32.3
```
Example python code:
```
import requests

def lambda_handler(event, context):
   response = requests.get("https://httpbin.org/get", timeout=10)
   print(response.json())
```
Lambda function execution error:
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'lambda_function_test': No module named 'requests'
Traceback (most recent call last):
```
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
The `master` has been pulled, implemeted the proposed change, used new source module `source = "../terraform-aws-lambda"` on the previously described module usage, returned output:
```
Status: Succeeded
Test Event Name: TEST_EVENT

Response:
null

Function Logs:
START RequestId: 224fb8c9-8590-41e8-abff-8b995e23115d Version: $LATEST
{'args': {}, 'headers': {'Accept': '*/*', 'Accept-Encoding': 'gzip, deflate', 'Host': 'httpbin.org', 'User-Agent': 'python-requests/2.32.3', 'X-Amzn-Trace-Id': 'Root=1-6841ccba-632cc83457388d0c4fc43ba5'}, 'origin': '98.83.38.2', 'url': 'https://httpbin.org/get'}
END RequestId: 224fb8c9-8590-41e8-abff-8b995e23115d
REPORT RequestId: 224fb8c9-8590-41e8-abff-8b995e23115d	Duration: 8978.87 ms	Billed Duration: 8979 ms	Memory Size: 128 MB	Max Memory Used: 53 MB	Init Duration: 355.96 ms

Request ID: 224fb8c9-8590-41e8-abff-8b995e23115d
```