### PR TITLE
fix: Replace count with for_each in additional_many policy attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ There are 6 supported ways to attach IAM policies to IAM role used by Lambda Fun
 1. `policy_json` - JSON string or heredoc, when `attach_policy_json = true`.
 1. `policy_jsons` - List of JSON strings or heredoc, when `attach_policy_jsons = true` and `number_of_policy_jsons > 0`.
 1. `policy` - ARN of existing IAM policy, when `attach_policy = true`.
-1. `policies` - List of ARNs of existing IAM policies, when `attach_policies = true` and `number_of_policies > 0`.
+1. `policies` - List of ARNs of existing IAM policies, when `attach_policies = true`.
 1. `policy_statements` - Map of maps to define IAM statements which will be generated as IAM policy. Requires `attach_policy_statements = true`. See `examples/complete` for more information.
 1. `assume_role_policy_statements` - Map of maps to define IAM statements which will be generated as IAM policy for assuming Lambda Function role (trust relationship). See `examples/complete` for more information.
 
@@ -814,7 +814,6 @@ No modules.
 | <a name="input_maximum_event_age_in_seconds"></a> [maximum\_event\_age\_in\_seconds](#input\_maximum\_event\_age\_in\_seconds) | Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600. | `number` | `null` | no |
 | <a name="input_maximum_retry_attempts"></a> [maximum\_retry\_attempts](#input\_maximum\_retry\_attempts) | Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2. | `number` | `null` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MB your Lambda Function can use at runtime. Valid value between 128 MB to 10,240 MB (10 GB), in 64 MB increments. | `number` | `128` | no |
-| <a name="input_number_of_policies"></a> [number\_of\_policies](#input\_number\_of\_policies) | Number of policies to attach to IAM role for Lambda Function | `number` | `0` | no |
 | <a name="input_number_of_policy_jsons"></a> [number\_of\_policy\_jsons](#input\_number\_of\_policy\_jsons) | Number of policies JSON to attach to IAM role for Lambda Function | `number` | `0` | no |
 | <a name="input_package_type"></a> [package\_type](#input\_package\_type) | The Lambda deployment package type. Valid options: Zip or Image | `string` | `"Zip"` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | List of policy statements ARN to attach to Lambda Function role | `list(string)` | `[]` | no |

--- a/examples/alias/main.tf
+++ b/examples/alias/main.tf
@@ -38,7 +38,7 @@ module "lambda_function" {
   policies = [
     "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole",
   ]
-  number_of_policies = 1
+
 
   allowed_triggers = {
     APIGatewayAny = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -158,7 +158,7 @@ module "lambda_function" {
 
   attach_policies    = true
   policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
-  number_of_policies = 1
+
 
   attach_policy_statements = true
   policy_statements = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -156,8 +156,8 @@ module "lambda_function" {
   attach_policy = true
   policy        = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 
-  attach_policies    = true
-  policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
+  attach_policies = true
+  policies        = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
 
 
   attach_policy_statements = true

--- a/examples/event-source-mapping/main.tf
+++ b/examples/event-source-mapping/main.tf
@@ -175,8 +175,7 @@ module "lambda_function" {
     }
   }
 
-  attach_policies    = true
-  number_of_policies = 3
+  attach_policies = true
 
   policies = [
     "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole",

--- a/examples/multiple-regions/main.tf
+++ b/examples/multiple-regions/main.tf
@@ -78,7 +78,7 @@ EOF
 
   attach_policies    = true
   policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
-  number_of_policies = 1
+
 
   attach_policy_statements = true
   policy_statements = {
@@ -175,7 +175,7 @@ EOF
 
   attach_policies    = true
   policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
-  number_of_policies = 1
+
 
   attach_policy_statements = true
   policy_statements = {

--- a/examples/multiple-regions/main.tf
+++ b/examples/multiple-regions/main.tf
@@ -76,8 +76,8 @@ EOF
   attach_policy = true
   policy        = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 
-  attach_policies    = true
-  policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
+  attach_policies = true
+  policies        = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
 
 
   attach_policy_statements = true
@@ -173,8 +173,8 @@ EOF
   attach_policy = true
   policy        = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 
-  attach_policies    = true
-  policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
+  attach_policies = true
+  policies        = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
 
 
   attach_policy_statements = true

--- a/iam.tf
+++ b/iam.tf
@@ -275,10 +275,10 @@ resource "aws_iam_role_policy_attachment" "additional_one" {
 ######################################
 
 resource "aws_iam_role_policy_attachment" "additional_many" {
-  count = local.create_role && var.attach_policies ? var.number_of_policies : 0
+  for_each = local.create_role && var.attach_policies ? toset(var.policies) : toset([])
 
   role       = aws_iam_role.lambda[0].name
-  policy_arn = var.policies[count.index]
+  policy_arn = each.value
 }
 
 ###############################

--- a/variables.tf
+++ b/variables.tf
@@ -610,11 +610,6 @@ variable "number_of_policy_jsons" {
   default     = 0
 }
 
-variable "number_of_policies" {
-  description = "Number of policies to attach to IAM role for Lambda Function"
-  type        = number
-  default     = 0
-}
 
 variable "attach_policy_statements" {
   description = "Controls whether policy_statements should be added to IAM role for Lambda Function"

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -89,7 +89,6 @@ module "wrapper" {
   maximum_event_age_in_seconds                 = try(each.value.maximum_event_age_in_seconds, var.defaults.maximum_event_age_in_seconds, null)
   maximum_retry_attempts                       = try(each.value.maximum_retry_attempts, var.defaults.maximum_retry_attempts, null)
   memory_size                                  = try(each.value.memory_size, var.defaults.memory_size, 128)
-  number_of_policies                           = try(each.value.number_of_policies, var.defaults.number_of_policies, 0)
   number_of_policy_jsons                       = try(each.value.number_of_policy_jsons, var.defaults.number_of_policy_jsons, 0)
   package_type                                 = try(each.value.package_type, var.defaults.package_type, "Zip")
   policies                                     = try(each.value.policies, var.defaults.policies, [])


### PR DESCRIPTION
## Summary
- Replaces `count` with `for_each` in `aws_iam_role_policy_attachment.additional_many`
- Uses policy ARN as the stable `for_each` key instead of list index
- Prevents unnecessary detach/reattach of **all** policies when one is removed from the front or middle of the list, which causes Lambda functions to temporarily lose access to external services during the destroy→attach cycle

## Problem
When using `count` with a list of policy ARNs, Terraform tracks attachments by index. Removing any item other than the last causes all subsequent resources to be re-indexed, triggering a full detach of all policies followed by reattachment of the remaining ones. During this window, the Lambda function loses IAM permissions.

## Solution
Switch to `for_each` with `toset(var.policies)`, using the ARN itself as the stable key. This ensures Terraform only destroys the specific attachment being removed, leaving all others untouched.

## Test plan
- [ ] Apply with existing policies — verify no changes detected
- [ ] Remove a policy from the front of the list — verify only that attachment is destroyed, others are untouched
- [ ] Verify Lambda functions retain external service access during policy changes