### PR TITLE
fix: Updating aws_region.current attribute reference 'region' to 'id'

### DIFF
--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -26,7 +26,7 @@ provider "aws" {
 
 provider "docker" {
   registry_auth {
-    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.region)
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.id)
     username = data.aws_ecr_authorization_token.token.user_name
     password = data.aws_ecr_authorization_token.token.password
   }

--- a/examples/with-vpc-s3-endpoint/main.tf
+++ b/examples/with-vpc-s3-endpoint/main.tf
@@ -26,7 +26,7 @@ module "lambda_s3_write" {
 
   environment_variables = {
     BUCKET_NAME = module.s3_bucket.s3_bucket_id
-    REGION_NAME = data.aws_region.current.region
+    REGION_NAME = data.aws_region.current.id
   }
 
   # Let the module create a role for us
@@ -54,7 +54,7 @@ resource "random_pet" "this" {
 }
 
 data "aws_ec2_managed_prefix_list" "this" {
-  name = "com.amazonaws.${data.aws_region.current.region}.s3"
+  name = "com.amazonaws.${data.aws_region.current.id}.s3"
 }
 
 module "vpc" {
@@ -64,7 +64,7 @@ module "vpc" {
   name = random_pet.this.id
   cidr = "10.0.0.0/16"
 
-  azs = ["${data.aws_region.current.region}a", "${data.aws_region.current.region}b", "${data.aws_region.current.region}c"]
+  azs = ["${data.aws_region.current.id}a", "${data.aws_region.current.id}b", "${data.aws_region.current.id}c"]
 
   # Intra subnets are designed to have no Internet access via NAT Gateway.
   intra_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -3,7 +3,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "this" {}
 
 locals {
-  ecr_address    = coalesce(var.ecr_address, format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.region))
+  ecr_address    = coalesce(var.ecr_address, format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.this.account_id, data.aws_region.current.id))
   ecr_repo       = var.create_ecr_repo ? aws_ecr_repository.this[0].id : var.ecr_repo
   image_tag      = var.use_image_tag ? coalesce(var.image_tag, formatdate("YYYYMMDDhhmmss", timestamp())) : null
   ecr_image_name = var.use_image_tag ? format("%v/%v:%v", local.ecr_address, local.ecr_repo, local.image_tag) : format("%v/%v", local.ecr_address, local.ecr_repo)

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@ output "lambda_function_arn" {
 
 output "lambda_function_arn_static" {
   description = "The static ARN of the Lambda Function. Use this to avoid cycle errors between resources (e.g., Step Functions)"
-  value       = local.create && var.create_function && !var.create_layer ? "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}" : ""
+  value       = local.create && var.create_function && !var.create_layer ? "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}" : ""
 }
 
 output "lambda_function_code_sha256" {


### PR DESCRIPTION
## Description

AWS Terraform provider version 6.0+ has removed the `region` attribute from the aws_region data source. See here: https://registry.terraform.io/providers/hashicorp/aws/6.40.0/docs/data-sources/region#attribute-reference

## Motivation and Context

This has caused issues upgrading to Terraform AWS provider version 6

## Breaking Changes

N/A

## How Has This Been Tested?

Tested locally, will provide details here shortly.
