### PR TITLE
fix: Fix uv.lock check for running uv export with --frozen

### DIFF
--- a/package.py
+++ b/package.py
@@ -1583,7 +1583,7 @@ def install_uv_dependencies(query, path, uv_export_extra_args, tmp_dir):
                 "requirements.txt",
             ]
 
-            user_lock_exists = os.path.exists(uv_lock_file)
+            user_lock_exists = os.path.exists("uv.lock")
             if user_lock_exists:
                 uv_export.append("--frozen")
 


### PR DESCRIPTION
## Description
The check for the uv.lock file is done while inside the temp directory, which only contains the pyproject.toml and uv.lock files. So the check always fails if the `source_path` is a directory, as the `uv_lock_file` variable set further up includes the directory path.

## Motivation and Context
This change fixes the check so it finds the uv.lock file in the current (temp) directory if it exists, and therefore sets the `--frozen` option correctly.

## Breaking Changes
None, unless users are relying on the behaviour that dependencies are being installed which don't match those defined in the uv.lock file. I.e. the behaviour of `uv export` without `--frozen`.

## How Has This Been Tested?
I have tested this with the `package_dir_uv` example. I didn't need to modify the example; it is currently not working correctly (i.e. it doesn't pass `--frozen` even though a lock file is present in the fixture). With my change, `--frozen` is now passed in correctly.