### PR TITLE
fix: Attempt docker pull before docker build when image not found locally

### DIFF
--- a/package.py
+++ b/package.py
@@ -1182,12 +1182,15 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
                     ok = True
                 if ok:
                     break
-                docker_cmd = docker_build_command(
-                    build_root=docker_build_root,
-                    docker_file=docker_file,
-                    tag=docker_image,
-                )
-                check_call(docker_cmd)
+                try:
+                    check_call(docker_pull_command(docker_image))
+                except CalledProcessError:
+                    docker_cmd = docker_build_command(
+                        build_root=docker_build_root,
+                        docker_file=docker_file,
+                        tag=docker_image,
+                    )
+                    check_call(docker_cmd)
                 ok = True
         elif docker_file or docker_build_root:
             raise ValueError(
@@ -1325,12 +1328,15 @@ def install_poetry_dependencies(query, path, poetry_export_extra_args, tmp_dir):
                     ok = True
                 if ok:
                     break
-                docker_cmd = docker_build_command(
-                    build_root=docker_build_root,
-                    docker_file=docker_file,
-                    tag=docker_image,
-                )
-                check_call(docker_cmd)
+                try:
+                    check_call(docker_pull_command(docker_image))
+                except CalledProcessError:
+                    docker_cmd = docker_build_command(
+                        build_root=docker_build_root,
+                        docker_file=docker_file,
+                        tag=docker_image,
+                    )
+                    check_call(docker_cmd)
                 ok = True
         elif docker_file or docker_build_root:
             raise ValueError(
@@ -1522,12 +1528,15 @@ def install_uv_dependencies(query, path, uv_export_extra_args, tmp_dir):
                 check_output(docker_image_id_command(docker_image)).decode().strip()
             )
             if not output:
-                docker_cmd = docker_build_command(
-                    build_root=docker_build_root,
-                    docker_file=docker_file,
-                    tag=docker_image,
-                )
-                check_call(docker_cmd)
+                try:
+                    check_call(docker_pull_command(docker_image))
+                except CalledProcessError:
+                    docker_cmd = docker_build_command(
+                        build_root=docker_build_root,
+                        docker_file=docker_file,
+                        tag=docker_image,
+                    )
+                    check_call(docker_cmd)
                 output = (
                     check_output(docker_image_id_command(docker_image)).decode().strip()
                 )
@@ -1703,12 +1712,15 @@ def install_npm_requirements(query, requirements_file, tmp_dir):
                     ok = True
                 if ok:
                     break
-                docker_cmd = docker_build_command(
-                    build_root=docker_build_root,
-                    docker_file=docker_file,
-                    tag=docker_image,
-                )
-                check_call(docker_cmd)
+                try:
+                    check_call(docker_pull_command(docker_image))
+                except CalledProcessError:
+                    docker_cmd = docker_build_command(
+                        build_root=docker_build_root,
+                        docker_file=docker_file,
+                        tag=docker_image,
+                    )
+                    check_call(docker_cmd)
                 ok = True
         elif docker_file or docker_build_root:
             raise ValueError(
@@ -1833,6 +1845,14 @@ class TemporaryCopy:
 def docker_image_id_command(tag):
     """"""
     docker_cmd = ["docker", "images", "--format={{.ID}}", tag]
+    cmd_log.info(shlex_join(docker_cmd))
+    log_handler and log_handler.flush()
+    return docker_cmd
+
+
+def docker_pull_command(tag):
+    """"""
+    docker_cmd = ["docker", "pull", tag]
     cmd_log.info(shlex_join(docker_cmd))
     log_handler and log_handler.flush()
     return docker_cmd


### PR DESCRIPTION
## Description

Fixes #746

When `build_in_docker = true` and `docker_image` is set to a pre-built public registry image (e.g. `public.ecr.aws/sam/build-python3.12:latest`), if the image is not present locally, `package.py` falls back directly to `docker build` using `docker_build_root` as the build context. Since Lambda source directories typically don't contain a Dockerfile, this fails with:

```
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

## Changes

- Added `docker_pull_command()` helper function alongside existing `docker_image_id_command()` and `docker_build_command()`
- Modified all 4 docker image resolution paths (pip, poetry, npm/yarn, uv) to attempt `docker pull` before falling back to `docker build`
- If `docker pull` fails (e.g. for custom/local images), it falls back to the original `docker build` behavior

## Impact

- Pre-built registry images: `docker pull` succeeds, image is available locally
- Custom images with Dockerfile: `docker pull` fails, falls back to `docker build` (same as before)
- Already-local images: no change (image found in `docker images` check)