### PR TITLE
feat: Add `response_streaming_invoke_arn` to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,12 +882,12 @@ No modules.
 | <a name="output_lambda_function_arn_static"></a> [lambda\_function\_arn\_static](#output\_lambda\_function\_arn\_static) | The static ARN of the Lambda Function. Use this to avoid cycle errors between resources (e.g., Step Functions) |
 | <a name="output_lambda_function_code_sha256"></a> [lambda\_function\_code\_sha256](#output\_lambda\_function\_code\_sha256) | The base64-encoded representation of the source code package file |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
-| <a name="output_lambda_function_response_streaming_invoke_arn"></a> [lambda\_function\_response\_streaming\_invoke\_arn](#output\_lambda\_function\_response\_streaming\_invoke\_arn) | The Response Streaming Invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_kms_key_arn"></a> [lambda\_function\_kms\_key\_arn](#output\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
 | <a name="output_lambda_function_last_modified"></a> [lambda\_function\_last\_modified](#output\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
 | <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda Function |
 | <a name="output_lambda_function_qualified_arn"></a> [lambda\_function\_qualified\_arn](#output\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
 | <a name="output_lambda_function_qualified_invoke_arn"></a> [lambda\_function\_qualified\_invoke\_arn](#output\_lambda\_function\_qualified\_invoke\_arn) | The Invoke ARN identifying your Lambda Function Version |
+| <a name="output_lambda_function_response_streaming_invoke_arn"></a> [lambda\_function\_response\_streaming\_invoke\_arn](#output\_lambda\_function\_response\_streaming\_invoke\_arn) | The Response Streaming Invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_signing_job_arn"></a> [lambda\_function\_signing\_job\_arn](#output\_lambda\_function\_signing\_job\_arn) | ARN of the signing job |
 | <a name="output_lambda_function_signing_profile_version_arn"></a> [lambda\_function\_signing\_profile\_version\_arn](#output\_lambda\_function\_signing\_profile\_version\_arn) | ARN of the signing profile version |
 | <a name="output_lambda_function_source_code_hash"></a> [lambda\_function\_source\_code\_hash](#output\_lambda\_function\_source\_code\_hash) | The user-defined hash of the source code package file |

--- a/README.md
+++ b/README.md
@@ -882,6 +882,7 @@ No modules.
 | <a name="output_lambda_function_arn_static"></a> [lambda\_function\_arn\_static](#output\_lambda\_function\_arn\_static) | The static ARN of the Lambda Function. Use this to avoid cycle errors between resources (e.g., Step Functions) |
 | <a name="output_lambda_function_code_sha256"></a> [lambda\_function\_code\_sha256](#output\_lambda\_function\_code\_sha256) | The base64-encoded representation of the source code package file |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_lambda_function_response_streaming_invoke_arn"></a> [lambda\_function\_response\_streaming\_invoke\_arn](#output\_lambda\_function\_response\_streaming\_invoke\_arn) | The Response Streaming Invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_kms_key_arn"></a> [lambda\_function\_kms\_key\_arn](#output\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
 | <a name="output_lambda_function_last_modified"></a> [lambda\_function\_last\_modified](#output\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
 | <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda Function |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -74,6 +74,7 @@ No inputs.
 | <a name="output_lambda_function_arn_static"></a> [lambda\_function\_arn\_static](#output\_lambda\_function\_arn\_static) | The static ARN of the Lambda Function. Use this to avoid cycle errors between resources (e.g., Step Functions) |
 | <a name="output_lambda_function_code_sha256"></a> [lambda\_function\_code\_sha256](#output\_lambda\_function\_code\_sha256) | The base64-encoded representation of the source code package file |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_lambda_function_response_streaming_invoke_arn"></a> [lambda\_function\_response\_streaming\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Response Streaming Invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_kms_key_arn"></a> [lambda\_function\_kms\_key\_arn](#output\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
 | <a name="output_lambda_function_last_modified"></a> [lambda\_function\_last\_modified](#output\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
 | <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda Function |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -74,12 +74,12 @@ No inputs.
 | <a name="output_lambda_function_arn_static"></a> [lambda\_function\_arn\_static](#output\_lambda\_function\_arn\_static) | The static ARN of the Lambda Function. Use this to avoid cycle errors between resources (e.g., Step Functions) |
 | <a name="output_lambda_function_code_sha256"></a> [lambda\_function\_code\_sha256](#output\_lambda\_function\_code\_sha256) | The base64-encoded representation of the source code package file |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
-| <a name="output_lambda_function_response_streaming_invoke_arn"></a> [lambda\_function\_response\_streaming\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Response Streaming Invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_kms_key_arn"></a> [lambda\_function\_kms\_key\_arn](#output\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
 | <a name="output_lambda_function_last_modified"></a> [lambda\_function\_last\_modified](#output\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
 | <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda Function |
 | <a name="output_lambda_function_qualified_arn"></a> [lambda\_function\_qualified\_arn](#output\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
 | <a name="output_lambda_function_qualified_invoke_arn"></a> [lambda\_function\_qualified\_invoke\_arn](#output\_lambda\_function\_qualified\_invoke\_arn) | The Invoke ARN identifying your Lambda Function Version |
+| <a name="output_lambda_function_response_streaming_invoke_arn"></a> [lambda\_function\_response\_streaming\_invoke\_arn](#output\_lambda\_function\_response\_streaming\_invoke\_arn) | The Response Streaming Invoke ARN of the Lambda Function |
 | <a name="output_lambda_function_source_code_hash"></a> [lambda\_function\_source\_code\_hash](#output\_lambda\_function\_source\_code\_hash) | The user-defined hash of the source code package file |
 | <a name="output_lambda_function_source_code_size"></a> [lambda\_function\_source\_code\_size](#output\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
 | <a name="output_lambda_function_url"></a> [lambda\_function\_url](#output\_lambda\_function\_url) | The URL of the Lambda Function URL |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -19,6 +19,11 @@ output "lambda_function_invoke_arn" {
   value       = module.lambda_function.lambda_function_invoke_arn
 }
 
+output "lambda_function_response_streaming_invoke_arn" {
+  description = "The Response Streaming Invoke ARN of the Lambda Function"
+  value       = module.lambda_function.lambda_function_response_streaming_invoke_arn
+}
+
 output "lambda_function_name" {
   description = "The name of the Lambda Function"
   value       = module.lambda_function.lambda_function_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "lambda_function_invoke_arn" {
   value       = try(aws_lambda_function.this[0].invoke_arn, "")
 }
 
+output "lambda_function_response_streaming_invoke_arn" {
+  description = "The Response Streaming Invoke ARN of the Lambda Function"
+  value       = try(aws_lambda_function.this[0].response_streaming_invoke_arn, "")
+}
+
 output "lambda_function_name" {
   description = "The name of the Lambda Function"
   value       = try(aws_lambda_function.this[0].function_name, "")


### PR DESCRIPTION
## Description
Add `lambda_function_response_streaming_invoke_arn` output which is a direct forward of the existing `aws_lambda_function.response_streaming_invoke_arn` output.

## Motivation and Context
As of now, if the Response Streaming Invoke ARN is needed outside of this module, it has to be derived from the `invoke_arn` when it should be able use the native output of the `aws_lambda_function` resource instead.

One example is when streaming responses from API Gateway, something similar to the following is needed to use as `uri` in an `aws_api_gateway_integration` when `response_transfer_mode  = "STREAM"` is used:
```tf
resource "aws_api_gateway_integration" "myapi_resource_post" {
  # other attributes...
  response_transfer_mode  = "STREAM"
  uri = replace(
    replace(
      module.mylambda.lambda_function_invoke_arn,
      "2015-03-31", "2021-11-15"
    ),
    "/invocations", "/response-streaming-invocations"
  )
}
```

Instead, the following could be done when using the output added through this PR:

```tf
resource "aws_api_gateway_integration" "myapi_resource_post" {
  # other attributes...
  response_transfer_mode  = "STREAM"
  uri = module.mylambda.lambda_function_response_streaming_invoke_arn
}
```

The workaround is inspired by the suggestion in [hashicorp/terraform-provider-aws#45649](https://github.com/hashicorp/terraform-provider-aws/issues/45649)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
  - I updated `examples/complete` by adding a new output to it which forwards the module's output
  - Its `README.md` was updated accordingly via `terraform-docs`
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - After performing `terraform apply`, the new output was printed to the CLI.
  - This is the relevant line (I replaced my AWS account number with `XXXXXXXXXXXX`):
`lambda_function_response_streaming_invoke_arn = "arn:aws:apigateway:eu-west-1:lambda:path/2021-11-15/functions/arn:aws:lambda:eu-west-1:XXXXXXXXXXXX:function:capable-crayfish-lambda1/response-streaming-invocations"`
- [x] I have executed `pre-commit run -a` on my pull request
