### PR TITLE
fix(package): Surface subprocess stderr through `ZipWriter.__exit__`

### DIFF
--- a/package.py
+++ b/package.py
@@ -20,6 +20,7 @@ import tempfile
 import operator
 import platform
 import subprocess
+import threading
 from subprocess import check_call, check_output, CalledProcessError
 from contextlib import contextmanager
 from base64 import b64encode
@@ -352,7 +353,28 @@ class ZipWriteStream:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None:
-            self._log.exception("Error during zip archive creation")
+            # If the failure is a CalledProcessError that captured stderr,
+            # surface that stderr in the log so the operator can see what
+            # the underlying subprocess (typically pip) actually said.
+            # Without this, every pip-install failure inside the zip
+            # context surfaces only the generic line below, requiring the
+            # operator to fork + instrument package.py to debug.
+            if exc_type is subprocess.CalledProcessError and getattr(
+                exc_val, "stderr", None
+            ):
+                stderr_text = (
+                    exc_val.stderr.decode("utf-8", errors="replace")
+                    if isinstance(exc_val.stderr, (bytes, bytearray))
+                    else str(exc_val.stderr)
+                )
+                self._log.error(
+                    "Subprocess failed during zip archive creation: %s\n"
+                    "Captured stderr:\n%s",
+                    exc_val.cmd,
+                    stderr_text,
+                )
+            else:
+                self._log.exception("Error during zip archive creation")
             self.close(failed=True)
             raise SystemExit(1)
         self.close()
@@ -1266,6 +1288,9 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
                 log_handler and log_handler.flush()
                 try:
                     if query.quiet:
+                        # quiet: swallow both streams, exit code only.
+                        # On failure, the raised CalledProcessError will
+                        # carry no stderr — the operator wanted quiet.
                         check_call(
                             pip_command,
                             env=subproc_env,
@@ -1273,7 +1298,38 @@ def install_pip_requirements(query, requirements_file, tmp_dir):
                             stderr=subprocess.DEVNULL,
                         )
                     else:
-                        check_call(pip_command, env=subproc_env)
+                        # Non-quiet: stream pip output to the console as
+                        # before AND capture stderr separately. Capturing
+                        # via `subprocess.run(..., stderr=PIPE)` would
+                        # mean pip's stderr no longer streams in real
+                        # time, which hurts UX for long-running installs.
+                        # Tee instead: a thread reads pip's stderr line
+                        # by line, writes to sys.stderr (real-time) AND
+                        # accumulates into a buffer for the CalledProcessError.
+                        process = subprocess.Popen(
+                            pip_command,
+                            env=subproc_env,
+                            stderr=subprocess.PIPE,
+                            text=False,
+                        )
+                        stderr_buf = bytearray()
+
+                        def _tee():
+                            for chunk in iter(lambda: process.stderr.read(4096), b""):
+                                sys.stderr.buffer.write(chunk)
+                                sys.stderr.flush()
+                                stderr_buf.extend(chunk)
+
+                        tee_thread = threading.Thread(target=_tee, daemon=True)
+                        tee_thread.start()
+                        rc = process.wait()
+                        tee_thread.join()
+                        if rc != 0:
+                            raise subprocess.CalledProcessError(
+                                rc,
+                                pip_command,
+                                stderr=bytes(stderr_buf),
+                            )
                 except FileNotFoundError as e:
                     raise RuntimeError(
                         "Python interpreter version equal "


### PR DESCRIPTION
Closes #757.

## Description

When `pip install` (or any `subprocess.check_call` inside a `ZipWriter` context manager) fails, the resulting `CalledProcessError` propagates up to `ZipWriter.__exit__`, which logs a generic `Error during zip archive creation` line and re-raises `SystemExit`. The actual pip stderr — already streamed to the parent's stderr by `check_call` — is no longer visible by the time the operator sees the failure, because terraform's `local-exec` keeps only the last ~30 lines of combined output and the Python traceback pushes pip's stderr out of that window.

Issue #757 describes the failure mode and repro in detail.

## Fix

Two changes in `package.py`:

### 1. `install_pip_requirements` (lines 1289–1336)

The quiet branch is unchanged: `check_call` with both streams to `DEVNULL`. Operators who opted into silence keep silence.

The non-quiet branch now uses a `subprocess.Popen` that tee's pip's stderr in real time:
- stderr chunks are written to `sys.stderr` as they arrive (preserves the streaming UX during long installs — important for `pip install -r requirements.txt` against a large dependency tree)
- the same chunks are accumulated into a buffer
- on non-zero exit, we raise `CalledProcessError(rc, cmd, stderr=<captured>)` ourselves so the exception carries the captured stderr

### 2. `ZipWriter.__exit__` (lines 353–377)

When the propagated exception is a `CalledProcessError` that has `.stderr` set, log the failing command + captured stderr explicitly instead of the misleading generic message. For all other exception types, log path unchanged.

## Behavioural impact

| Path | Before | After |
|---|---|---|
| Success | streams pip output, builds zip | unchanged |
| Non-quiet failure | streams pip output + "Error during zip archive creation" + traceback | streams pip output **and** captures stderr; final log line shows pip's stderr instead of the generic message |
| Quiet failure (`query.quiet = True`) | silent + generic message | unchanged (no stderr captured by design) |

Anyone relying on quiet=True silence sees no behavioural change.

## Test plan

Local repro: create a `requirements.txt` with a package that fails to install (e.g. a name pinning to a non-existent version), drive a `lambda_layer_pip_requirements` module against it.

Before this PR:
```
Error: Error during zip archive creation
  File ".terraform/.../package.py", line 357, in __exit__
    raise SystemExit(1)
SystemExit: 1
```

After this PR:
```
Error: Subprocess failed during zip archive creation: ['python3.12', '-m', 'pip', 'install', ...]
Captured stderr:
  ERROR: Could not find a version that satisfies the requirement nonexistent-package==99.0
  ERROR: No matching distribution found for nonexistent-package==99.0
```
