### PR TITLE
fix: Bump dessant/lock-threads to v6

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,7 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-comment: >


### PR DESCRIPTION
## Description

(During my investigation to why v8.8.1 is not released to the tf registry, though not related) I noticed the scheduled **Lock Threads** workflow has been failing on every run (e.g. [run #27857912049](https://github.com/terraform-aws-modules/terraform-aws-lambda/actions/runs/27857912049/job/82448661872)):

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

`dessant/lock-threads@v5` validates `github-token` with a `Joi.string().trim().max(100)` schema. GitHub's `GITHUB_TOKEN` now exceeds 100 characters, so the input fails validation and the job errors out before doing anything.

`dessant/lock-threads@v6` raises that cap to `max(1000)`, which resolves the failure. It also moves the action runtime to `node24`, clearing the `Node.js 20 is deprecated` warning that the same run emits.

This bumps the action `v5` → `v6`. No input changes are required — all inputs used by this workflow are unchanged in v6.
