### PR TITLE
feat: Add region variable to alias submodule for provider v6 resource-level region

### DIFF
--- a/modules/alias/README.md
+++ b/modules/alias/README.md
@@ -161,6 +161,7 @@ No modules.
 | <a name="input_maximum_retry_attempts"></a> [maximum\_retry\_attempts](#input\_maximum\_retry\_attempts) | Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. Defaults to 2. | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for the alias you are creating. | `string` | `""` | no |
 | <a name="input_refresh_alias"></a> [refresh\_alias](#input\_refresh\_alias) | Whether to refresh function version used in the alias. Useful when using this module together with external tool do deployments (eg, AWS CodeDeploy). | `bool` | `true` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the region set in the provider configuration | `string` | `null` | no |
 | <a name="input_routing_additional_version_weights"></a> [routing\_additional\_version\_weights](#input\_routing\_additional\_version\_weights) | A map that defines the proportion of events that should be sent to different versions of a lambda function. | `map(number)` | `{}` | no |
 | <a name="input_use_existing_alias"></a> [use\_existing\_alias](#input\_use\_existing\_alias) | Whether to manage existing alias instead of creating a new one. Useful when using this module together with external tool do deployments (eg, AWS CodeDeploy). | `bool` | `false` | no |
 

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -7,12 +7,16 @@ locals {
 data "aws_lambda_alias" "existing" {
   count = var.create && var.use_existing_alias ? 1 : 0
 
+  region = var.region
+
   function_name = var.function_name
   name          = var.name
 }
 
 resource "aws_lambda_alias" "no_refresh" {
   count = var.create && !var.use_existing_alias && !var.refresh_alias ? 1 : 0
+
+  region = var.region
 
   name        = var.name
   description = var.description
@@ -36,6 +40,8 @@ resource "aws_lambda_alias" "no_refresh" {
 resource "aws_lambda_alias" "with_refresh" {
   count = var.create && !var.use_existing_alias && var.refresh_alias ? 1 : 0
 
+  region = var.region
+
   name        = var.name
   description = var.description
 
@@ -53,6 +59,8 @@ resource "aws_lambda_alias" "with_refresh" {
 
 resource "aws_lambda_function_event_invoke_config" "this" {
   for_each = var.create && var.create_async_event_config ? local.qualifiers : {}
+
+  region = var.region
 
   function_name = var.function_name
   qualifier     = each.key == "version" ? local.version : var.name
@@ -83,6 +91,8 @@ resource "aws_lambda_function_event_invoke_config" "this" {
 resource "aws_lambda_permission" "version_triggers" {
   for_each = var.create && var.create_version_allowed_triggers ? var.allowed_triggers : {}
 
+  region = var.region
+
   function_name = var.function_name
 
   # Error: Error adding new Lambda Permission for ... InvalidParameterValueException: We currently do not support adding policies for $LATEST.
@@ -100,6 +110,8 @@ resource "aws_lambda_permission" "version_triggers" {
 resource "aws_lambda_permission" "qualified_alias_triggers" {
   for_each = var.create && var.create_qualified_alias_allowed_triggers ? var.allowed_triggers : {}
 
+  region = var.region
+
   function_name = var.function_name
   qualifier     = var.name
 
@@ -114,6 +126,8 @@ resource "aws_lambda_permission" "qualified_alias_triggers" {
 
 resource "aws_lambda_event_source_mapping" "this" {
   for_each = { for k, v in var.event_source_mapping : k => v if var.create }
+
+  region = var.region
 
   function_name = local.alias_arn
 

--- a/modules/alias/variables.tf
+++ b/modules/alias/variables.tf
@@ -46,6 +46,12 @@ variable "create_qualified_alias_allowed_triggers" {
   default     = true
 }
 
+variable "region" {
+  description = "Region where the resource(s) will be managed. Defaults to the region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 ########
 # Alias
 ########

--- a/wrappers/alias/main.tf
+++ b/wrappers/alias/main.tf
@@ -20,6 +20,7 @@ module "wrapper" {
   maximum_retry_attempts                    = try(each.value.maximum_retry_attempts, var.defaults.maximum_retry_attempts, null)
   name                                      = try(each.value.name, var.defaults.name, "")
   refresh_alias                             = try(each.value.refresh_alias, var.defaults.refresh_alias, true)
+  region                                    = try(each.value.region, var.defaults.region, null)
   routing_additional_version_weights        = try(each.value.routing_additional_version_weights, var.defaults.routing_additional_version_weights, {})
   use_existing_alias                        = try(each.value.use_existing_alias, var.defaults.use_existing_alias, false)
 }


### PR DESCRIPTION
The `modules/alias` submodule had no `region` variable, so callers relying on the root module's provider-v6 resource-level `region` support could not guarantee the alias and its associated resources land in the same region as the function. They silently fell back to the provider's configured region, causing a `ResourceNotFoundException` at apply time when the function lived in a different region.

This adds an optional `region` variable (default `null`) to `modules/alias` and passes it to all seven regional resources, mirroring the root module's existing pattern:

- `data.aws_lambda_alias.existing`
- `aws_lambda_alias.no_refresh` / `aws_lambda_alias.with_refresh`
- `aws_lambda_function_event_invoke_config.this`
- `aws_lambda_permission.version_triggers` / `aws_lambda_permission.qualified_alias_triggers`
- `aws_lambda_event_source_mapping.this`

The `wrappers/alias` passthrough and the terraform-docs README row are included. Backward compatible: `default = null` is a no-op for existing users, and the provider requirement is already `>= 6.28` so no version bump is needed.

Validation (local, all green):
- `terraform fmt -check -recursive`: clean
- `terraform validate` (init -backend=false): Success
- `tflint`: exit 0
- `terraform-docs` (v0.20.0): README Inputs table in sync, region row added

closes #760