### PR TITLE
fix: Improve uv_install export when pyproject.toml is provided as path within source_path

### DIFF
--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
@@ -36,13 +36,13 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_lambda_function_from_package"></a> [lambda\_function\_from\_package](#module\_lambda\_function\_from\_package) | ../../ | n/a |
 | <a name="module_lambda_layer"></a> [lambda\_layer](#module\_lambda\_layer) | ../../ | n/a |
 | <a name="module_lambda_layer_pip_requirements"></a> [lambda\_layer\_pip\_requirements](#module\_lambda\_layer\_pip\_requirements) | ../.. | n/a |
@@ -65,6 +65,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_package_file_with_pip_requirements"></a> [package\_file\_with\_pip\_requirements](#module\_package\_file\_with\_pip\_requirements) | ../../ | n/a |
 | <a name="module_package_src_poetry"></a> [package\_src\_poetry](#module\_package\_src\_poetry) | ../../ | n/a |
 | <a name="module_package_src_poetry2"></a> [package\_src\_poetry2](#module\_package\_src\_poetry2) | ../../ | n/a |
+| <a name="module_package_uv_pyproject"></a> [package\_uv\_pyproject](#module\_package\_uv\_pyproject) | ../.. | n/a |
+| <a name="module_package_uv_pyproject_no_lock"></a> [package\_uv\_pyproject\_no\_lock](#module\_package\_uv\_pyproject\_no\_lock) | ../.. | n/a |
 | <a name="module_package_with_commands_and_patterns"></a> [package\_with\_commands\_and\_patterns](#module\_package\_with\_commands\_and\_patterns) | ../../ | n/a |
 | <a name="module_package_with_docker"></a> [package\_with\_docker](#module\_package\_with\_docker) | ../../ | n/a |
 | <a name="module_package_with_npm_lock_in_docker"></a> [package\_with\_npm\_lock\_in\_docker](#module\_package\_with\_npm\_lock\_in\_docker) | ../../ | n/a |
@@ -76,7 +78,7 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs

--- a/examples/build-package/README.md
+++ b/examples/build-package/README.md
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
@@ -36,13 +36,13 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_lambda_function_from_package"></a> [lambda\_function\_from\_package](#module\_lambda\_function\_from\_package) | ../../ | n/a |
 | <a name="module_lambda_layer"></a> [lambda\_layer](#module\_lambda\_layer) | ../../ | n/a |
 | <a name="module_lambda_layer_pip_requirements"></a> [lambda\_layer\_pip\_requirements](#module\_lambda\_layer\_pip\_requirements) | ../.. | n/a |
@@ -78,7 +78,7 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs

--- a/examples/build-package/main.tf
+++ b/examples/build-package/main.tf
@@ -174,6 +174,38 @@ module "package_dir_uv" {
   artifacts_dir = "${path.root}/builds/package_dir_uv/"
 }
 
+module "package_uv_pyproject" {
+  source = "../.."
+
+  create_function = false
+  runtime         = "python3.12"
+
+  source_path = [
+    {
+      path       = "${path.root}/../fixtures/python-app-uv/pyproject.toml"
+      uv_install = true
+    }
+  ]
+  artifacts_dir = "${path.root}/buids/package_uv_project"
+}
+
+
+module "package_uv_pyproject_no_lock" {
+  source = "../.."
+
+  create_function = false
+  runtime         = "python3.12"
+
+  source_path = [
+    {
+      path       = "${path.root}/../fixtures/python-app-uv-no-lock/pyproject.toml"
+      uv_install = true
+    }
+  ]
+  artifacts_dir = "${path.root}/builds/package_uv_pyproject_no_lock"
+}
+
+
 # Create zip-archive of a single directory where "uv export" & "pip install" will be executed (not using docker)
 module "package_dir_uv_no_docker" {
   source = "../../"

--- a/package.py
+++ b/package.py
@@ -1552,13 +1552,9 @@ def install_uv_dependencies(query, path, uv_export_extra_args, tmp_dir):
         with open(requirements_file, "w") as f:
             f.write("\n".join(cleaned) + "\n")
 
-    uv_lock_file = path
-    if os.path.isdir(path):
-        uv_lock_file = os.path.join(path, "uv.lock")
-    project_path = (
-        os.path.dirname(uv_lock_file) if os.path.isdir(path) else os.path.dirname(path)
-    )
-    pyproject_file = os.path.join(project_path, "pyproject.toml")
+    dir_path = path if path == "/" or os.path.isdir(path) else os.path.dirname(path)
+    uv_lock_file = os.path.join(path, "uv.lock")
+    pyproject_file = os.path.join(dir_path, "pyproject.toml")
 
     runtime = query.runtime
     docker = query.docker


### PR DESCRIPTION
## Description
Fix uv_install bug when providing as path within source_path the value of the pyproject.toml file itself.

Currently, uv_install only works if path provided is a directory that contains pyproject.toml. If the path provided is the `pyproject.toml` file, the logic in `package.py` fails due to the previous assumption

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix is required for when you have a pyproject file defined in anyplace you want, and you are only interested in the pyproject file in the same directory
<!--- If it fixes an open issue, please link to the issue here. -->
This PR aims to fix the issue described [here](https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/763)
Fix #763 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Aside from creating two new examples within `examples/build-package/main.tf`, I use this simple test as well:

```sh
mkdir failing_uv_install && cd failing_uv_install
uv init --bare .
cat > main.tf <<EOF
module "failing_lambda_build" {
  source = "github.com/joyanedel/terraform-aws-lambda"

  create_function = false
  runtime         = "python3.14"

  source_path = [
    {
      path       = "pyproject.toml"
      uv_install = true
    }
  ]
}

provider "aws" {
  region = "eu-west-1"

  # Make it faster by skipping something
  skip_metadata_api_check     = true
  skip_region_validation      = true
  skip_credentials_validation = true
}

terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = ">= 6.28"
    }
  }
}
EOF
terraform init
terraform apply -auto-approve
```
